### PR TITLE
REL: Version bump: 1.1.6 > 1.1.7

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -67,6 +67,9 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: MBS-Artifacts/artifacts
+      - run: |
+          mv MBS-Artifacts/artifacts/artifact-main/main MBS-Artifacts/artifacts/main
+          mv MBS-Artifacts/artifacts/artifact-devel/devel MBS-Artifacts/artifacts/devel
       - name: Push new release artifacts to the MBS release archive
         if: github.event_name == 'release'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MBS Changelog
 
+## v1.1.7
+* Add R100Beta1 support
+* Backport two BC R100Beta2 fixes to R100Beta1:
+    - [BondageProjects/Bondage-College#4740](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/4740): Fix `PreferenceArousalSettingsValidate` calling the wrong cloning function
+    - [BondageProjects/Bondage-College#4741](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/4741): Ensure that the `GameVersion` validation modifies the players game version when required
+
 ## v1.1.6
 * Drop BC R98 support
 

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.1.6.dev0
+// @version      1.1.7.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.1.6
+// @version      1.1.7
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "@types/lodash-es": "^4.17.9",
-        "bc-stubs": "99.0.0",
+        "bc-stubs": "100.0.0-Beta.1",
         "bondage-club-mod-sdk": "^1.1.0",
         "lodash-es": "^4.17.21"
     },

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -1,7 +1,6 @@
 /** Backports of R91 bug fixes */
 
 import { waitFor, logger, MBS_MOD_API } from "common";
-import { settingsMBSLoaded } from "common_bc";
 import { sortBy } from "lodash-es";
 import { BC_MIN_VERSION } from "sanity_checks";
 
@@ -11,7 +10,7 @@ const BC_NEXT = BC_MIN_VERSION + 1;
 /** A set with the pull request IDs of all applied bug fix backports */
 export const backportIDs: Set<number> = new Set();
 
-waitFor(settingsMBSLoaded).then(() => {
+waitFor(() => typeof GameVersion === "string").then(() => {
     switch (GameVersion) {
         case "R99": {
             if (MBS_MOD_API.getOriginalHash("CraftingDeserialize") === "208F6080") {
@@ -23,8 +22,36 @@ waitFor(settingsMBSLoaded).then(() => {
                         "OverridePriority, ItemProperty,",
                 });
             }
+            break;
+        }
+        case "R100Beta1": {
+            backportIDs.add(4740);
+            MBS_MOD_API.patchFunction("PreferenceArousalSettingsValidate.Activity", {
+                "ret.push(...cloneDeep":
+                    "ret.push(...CommonCloneDeep",
+            });
+            MBS_MOD_API.patchFunction("PreferenceArousalSettingsValidate.Zone", {
+                "ret.push(...cloneDeep":
+                    "ret.push(...CommonCloneDeep",
+            });
+            MBS_MOD_API.patchFunction("PreferenceArousalSettingsValidate.Fetish", {
+                "ret.push(...cloneDeep":
+                    "ret.push(...CommonCloneDeep",
+            });
+
+            backportIDs.add(4741);
+            MBS_MOD_API.patchFunction("PreferenceOnlineSharedSettingsValidate.GameVersion", {
+                "const version = ":
+                    "let version = ",
+                "if (C.IsPlayer() && CommonCompareVersion(GameVersion, C.OnlineSharedSettings.GameVersion) < 0)":
+                    "if (C.IsPlayer())",
+                "CommonVersionUpdated = true;":
+                    'if (CommonCompareVersion(GameVersion, version ?? "R0") < 0) { CommonVersionUpdated = true; } version = GameVersion;',
+            });
+            break;
         }
     }
+
     if (backportIDs.size) {
         logger.log(`Initializing R${BC_NEXT} bug fix backports`, sortBy(Array.from(backportIDs)));
     } else {

--- a/src/fortune_wheel.ts
+++ b/src/fortune_wheel.ts
@@ -761,9 +761,6 @@ class FWScreenProxy extends ScreenProxy {
                     CommonSetScreen("MiniGame", "WheelFortune");
                     WheelFortuneLoad();
                 },
-                Unload: CommonNoop,
-                Resize: CommonNoop,
-                KeyDown: CommonNoop,
             },
         );
         this.character = Player;

--- a/src/screen_abc.ts
+++ b/src/screen_abc.ts
@@ -64,8 +64,9 @@ export abstract class MBSScreen {
     /**
      * Called when user presses any key
      * @param event - The event that triggered this
+     * @returns Whether a key was pressed
      */
-    keyDown?(event: KeyboardEvent): void;
+    keyDown?(event: KeyboardEvent): boolean;
 
     /**
      * Helper function for exiting all parents.
@@ -104,13 +105,13 @@ export abstract class MBSScreen {
 export class ScreenProxy extends MBSScreen {
     readonly module: string;
     readonly background: string;
-    readonly screenFunctions: Readonly<Required<ScreenFunctions>>;
+    readonly screenFunctions: Readonly<ScreenFunctions>;
 
     constructor(
         parent: null | MBSScreen,
         module: string,
         background: string,
-        screenFunctions: Readonly<Required<ScreenFunctions>>,
+        screenFunctions: Readonly<ScreenFunctions>,
     ) {
         super(parent);
         this.module = module;
@@ -120,11 +121,11 @@ export class ScreenProxy extends MBSScreen {
 
     run(time: number) { return this.screenFunctions.Run(time); }
     click(event: MouseEvent | TouchEvent) { return this.screenFunctions.Click(event); }
-    load() { return this.screenFunctions.Load(); }
-    unload() { return this.screenFunctions.Unload(); }
-    resize(load: boolean) { return this.screenFunctions.Resize(load); }
-    keyDown(event: KeyboardEvent) { return this.screenFunctions.KeyDown(event); }
-    exit() { return this.screenFunctions.Exit(); }
+    load() { return this.screenFunctions.Load?.(); }
+    unload() { return this.screenFunctions.Unload?.(); }
+    resize(load: boolean) { return this.screenFunctions.Resize?.(load); }
+    keyDown(event: KeyboardEvent) { return this.screenFunctions.KeyDown?.(event) ?? false; }
+    exit() { return this.screenFunctions.Exit?.(); }
 }
 
 export type ExitAction = 0 | 1 | 2;

--- a/src/settings_screen.ts
+++ b/src/settings_screen.ts
@@ -22,9 +22,6 @@ export class PreferenceScreenProxy extends ScreenProxy {
                 Click: PreferenceClick,
                 Exit: PreferenceExit,
                 Load: () => CommonSetScreen("Character", "Preference"),
-                Unload: CommonNoop,
-                Resize: CommonNoop,
-                KeyDown: CommonNoop,
             },
         );
         this.character = Player;


### PR DESCRIPTION
* Add R100Beta1 support
* Backport two BC R100Beta2 fixes to R100Beta1:
    - [BondageProjects/Bondage-College#4740](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/4740): Fix `PreferenceArousalSettingsValidate` calling the wrong cloning function
    - [BondageProjects/Bondage-College#4741](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/4741): Ensure that the `GameVersion` validation modifies the players game version when required