### PR TITLE
REL: Version bump: 1.3.2 > 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MBS Changelog
 
+## v1.3.3
+* Backport three BC R101 fixes to R100 (and fixed the KD one from MBS v1.3.2):
+    - [BondageProjects/Bondage-College#4777](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/4777): Fix eye colour reset on expression clear
+    - [BondageProjects/Bondage-College#4779](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/4779): Fix `Item.Property` not always properly initializing in KD
+    - [BondageProjects/Bondage-College#4780](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/4780): Fix the futuristic harness ball gag auto-inflation triggering validation
+
 ## v1.3.2
 * Add the ability to buy items from the Show New Items menu
 * Add safeguards in the MBS API for checking whether MBS is fully loaded already

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.3.2.dev0
+// @version      1.3.3.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.3.2
+// @version      1.3.3
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -21,20 +21,25 @@ waitFor(() => typeof MainCanvas !== "undefined").then(() => {
                         "const name = group.Name === 'Eyes' ? 'Eyes1' : group.Name;",
                 });
             }
+
             if (MBS_MOD_API.getOriginalHash("ArcadeKinkyDungeonStart") === "A62E58E4") {
                 let kdPatch = false;
+                backportIDs.add(4779);
                 MBS_MOD_API.hookFunction("ArcadeKinkyDungeonStart", 0, (args, next) => {
                     next(args);
                     if (!kdPatch) {
-                        MBS_MOD_API.patchFunction("KDApplyItemLegacy", {
-                            'placed.Property.LockedBy = inv.lock ? "MetalPadlock" : undefined;':
-                                'placed.Property ??= {}; placed.Property.LockedBy = inv.lock ? "MetalPadlock" : undefined;',
+                        waitFor(() => typeof ArcadeKinkyDungeonStart === "function").then(() => {
+                            MBS_MOD_API.patchFunction("KDApplyItemLegacy", {
+                                'placed.Property.LockedBy = inv.lock ? "MetalPadlock" : undefined;':
+                                    'placed.Property ??= {}; placed.Property.LockedBy = inv.lock ? "MetalPadlock" : undefined;',
+                            });
+                            kdPatch = true;
                         });
-                        kdPatch = true;
                     }
                 });
             }
 
+            backportIDs.add(4780);
             const data = ModularItemDataLookup["ItemMouthFuturisticHarnessBallGag"];
             const module = data?.modules?.find(m => m.Name === "Gag");
             module?.Options?.forEach(o => delete o.Property.OriginalSetting);


### PR DESCRIPTION
* Backport three BC R101 fixes to R100 (and fixed the KD one from MBS v1.3.2):
    - [BondageProjects/Bondage-College#4777](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/4777): Fix eye colour reset on expression clear
    - [BondageProjects/Bondage-College#4779](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/4779): Fix `Item.Property` not always properly initializing in KD
    - [BondageProjects/Bondage-College#4780](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/4780): Fix the futuristic harness ball gag auto-inflation triggering validation