### PR TITLE
REL: Version bump: 1.3.4 > 1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # MBS Changelog
 
+## v1.3.5
+* Refactor the logic for checking whether BC is properly loaded or not
+* Re-enable the storing of crafted item descriptions in the wheel of fortune, reverting their previous removal in MBS v0.6.22
+* Add checks to ensure that MBS does not exceed the 180 KB storage limit for its shared settings, exceeding of which can cause crashes and unstable behavior in BC
+
 ## v1.3.4
 * Add R101Beta2 support; no support for Beta1 will be added
 * Let the Show New Items menu display whether the player has F-/M-only shop items enabled

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.3.4.dev0
+// @version      1.3.5.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.3.4
+// @version      1.3.5
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     },
     "dependencies": {
         "@types/lodash-es": "^4.17.9",
-        "bc-data": "101.0.0-Beta.1",
-        "bc-stubs": "101.0.0-Beta.1",
+        "bc-data": "101.0.0-Beta.2",
+        "bc-stubs": "101.0.0-Beta.2",
         "bondage-club-mod-sdk": "^1.1.0",
         "lodash-es": "^4.17.21"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,5 @@
 import { logger, waitFor } from "../common";
-import { settingsMBSLoaded } from "../common_bc";
+import { settingsMBSLoaded, bcLoaded } from "../common_bc";
 
 import * as wheelOutfits from "./wheel_outfits";
 
@@ -38,7 +38,7 @@ export const getDebug: typeof mbs.getDebug = function getDebug() {
 };
 
 // Register the debugger to FUSAM
-waitFor(settingsMBSLoaded).then(() => {
+waitFor(bcLoaded).then(() => {
     if (typeof FUSAM !== "undefined" && typeof FUSAM.registerDebugMethod === "function") {
         FUSAM.registerDebugMethod("mbs", getDebug);
     }

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -3,6 +3,7 @@
 import { sortBy } from "lodash-es";
 
 import { waitFor, logger, MBS_MOD_API } from "./common";
+import { bcLoaded } from "./common_bc";
 import { BC_MIN_VERSION } from "./sanity_checks";
 
 /** The next BC version */
@@ -11,7 +12,7 @@ const BC_NEXT = BC_MIN_VERSION + 1;
 /** A set with the pull request IDs of all applied bug fix backports */
 export const backportIDs: Set<number> = new Set();
 
-waitFor(() => typeof MainCanvas !== "undefined").then(() => {
+waitFor(bcLoaded).then(() => {
     switch (GameVersion) {
         case "R100": {
             if (MBS_MOD_API.getOriginalHash("CharacterResetFacialExpression") === "C22A83C0") {

--- a/src/common.ts
+++ b/src/common.ts
@@ -393,7 +393,7 @@ export class Version {
     static fromBCVersion(version: string): Version {
         const match = GameVersionFormat.exec(version);
         if (match === null) {
-            throw new Error(`Invalid BC "version": ${version}`);
+            throw new Error(`Invalid BC version: "${version}"`);
         }
         return new Version(Number(match[1]), 0, 0, match[2] !== undefined);
     }

--- a/src/common_bc.ts
+++ b/src/common_bc.ts
@@ -104,12 +104,14 @@ export function sanitizeWheelFortuneIDs(IDs: string): string {
     return ret;
 }
 
+/** Whether BC had been loaded. */
+export function bcLoaded(testGameVersion=true): boolean {
+    return typeof MainCanvas === "object" && (testGameVersion ? GameVersionFormat.test(GameVersion) : true);
+}
+
 /** Return whether all vanilla BC online shared settings are loaded. */
 export function settingsLoaded(): boolean {
-    return (
-        typeof Player !== "undefined"
-        && Player.OnlineSharedSettings !== undefined
-    );
+    return bcLoaded() && Player.OnlineSharedSettings !== undefined;
 }
 
 /** Return whether all online settings (including MBS ones) are loaded. */

--- a/src/common_bc.ts
+++ b/src/common_bc.ts
@@ -1,6 +1,6 @@
 /** Miscellaneous common BC-related functions and classes */
 
-import { sortBy, omit } from "lodash-es";
+import { sortBy, omit, clamp } from "lodash-es";
 
 import {
     toStringTemplate,
@@ -1016,4 +1016,29 @@ export function createWeightedWheelIDs(ids: string): string {
         idList.push(...sortBy(idBaseList, Math.random));
     }
     return idList.join("");
+}
+
+export function drawHeaderedTooltip(x: number, y: number, w: number, deltaH: number, tooltip: string[]) {
+    MainCanvas.save();
+    try {
+        const [header, ...rest] = tooltip;
+        const h = deltaH + rest.length * 48 + (rest.length > 0 ? 16 : 0);
+        x = clamp(x, 0, 2000 - w);
+        y = clamp(y, 0, 1000 - h);
+
+        DrawRect(x, y, w, h, "White");
+        DrawEmptyRect(x, y, w, h, "Black", 2);
+        MainCanvas.beginPath();
+        MainCanvas.moveTo(x, y + deltaH);
+        MainCanvas.lineTo(x + w, y + deltaH);
+        MainCanvas.stroke();
+
+        MainCanvas.textBaseline = "middle";
+        DrawTextFit(header, x + (w / 2), y + deltaH / 2, w - 32, "black");
+        MainCanvas.textAlign = "left";
+        MainCanvas.font = '30px "Arial", sans-serif';
+        rest.forEach((str, i) => DrawText(str, x + 16, y + deltaH + 8 + 24 + i * 48, "black"));
+    } finally {
+        MainCanvas.restore();
+    }
 }

--- a/src/crafting/index.ts
+++ b/src/crafting/index.ts
@@ -1,7 +1,7 @@
 /** Main module for managing all crafting-related additions */
 
 import { MBS_MOD_API, waitFor, padArray, logger } from "../common";
-import { settingsMBSLoaded } from "../common_bc";
+import { settingsMBSLoaded, bcLoaded } from "../common_bc";
 import { pushMBSSettings, SettingsType } from "../settings";
 
 export const BC_SLOT_MAX_ORIGINAL = 80;
@@ -94,7 +94,7 @@ function loadCraftingCache(character: Character, craftingCache: string): void {
     }
 }
 
-waitFor(settingsMBSLoaded).then(() => {
+waitFor(bcLoaded).then(() => {
     logger.log("Initializing crafting hooks");
 
     // Mirror the extra MBS-specific crafted items to the MBS settings
@@ -122,5 +122,8 @@ waitFor(settingsMBSLoaded).then(() => {
             `/ ${MBS_SLOT_MAX_ORIGINAL / 20}.`,
     });
 
-    loadCraftingCache(Player, Player.MBSSettings.CraftingCache);
+    waitFor(settingsMBSLoaded).then(() => {
+        logger.log("Initializing crafting cache");
+        loadCraftingCache(Player, Player.MBSSettings.CraftingCache);
+    });
 });

--- a/src/fortune_wheel/equipper.ts
+++ b/src/fortune_wheel/equipper.ts
@@ -3,7 +3,7 @@
 import { cloneDeep, sortBy } from "lodash-es";
 
 import { BCX_MOD_API, waitFor, isArray, entries, includes, logger } from "../common";
-import { settingsMBSLoaded, canChangeCosplay, validateCharacter } from "../common_bc";
+import { bcLoaded, canChangeCosplay, validateCharacter } from "../common_bc";
 
 import { itemSetType, getBaselineProperty } from "./type_setting";
 
@@ -26,7 +26,7 @@ export const StripLevel = Object.freeze({
 
 /** A dummy character without any blocked or limited items. */
 let MBSDummy: Character;
-waitFor(settingsMBSLoaded).then(() => MBSDummy = CharacterLoadSimple("MBSDummy"));
+waitFor(bcLoaded).then(() => MBSDummy = CharacterLoadSimple("MBSDummy"));
 
 /**
  * Return that a callable that returns whether the passed asset satisfies the specified strip {@link StripLevel}

--- a/src/fortune_wheel/fortune_wheel.ts
+++ b/src/fortune_wheel/fortune_wheel.ts
@@ -18,6 +18,7 @@ import {
     canChangeCosplay,
     MBS_MAX_SETS,
     createWeightedWheelIDs,
+    bcLoaded,
 } from "../common_bc";
 import { validateBuiltinWheelIDs } from "../sanity_checks";
 import { ScreenProxy } from "../screen_abc";
@@ -781,62 +782,11 @@ class FWScreenProxy extends ScreenProxy {
 
 export let fortuneWheelState: FWScreenProxy;
 
-// Requires BC R88Beta1 or higher
-waitFor(settingsMBSLoaded).then(() => {
-    logger.log("Initializing wheel of fortune module");
+waitFor(bcLoaded).then(() => {
+    logger.log("Initializing wheel of fortune hooks");
     if (!validateBuiltinWheelIDs()) {
         return;
     }
-
-    // Load and register the default MBS item sets
-    FORTUNE_WHEEL_ITEMS = generateItems();
-    FORTUNE_WHEEL_ITEM_SETS = Object.freeze([
-        new FWItemSet(
-            "PSO Bondage",
-            FORTUNE_WHEEL_ITEMS.leash_candy,
-            Player.MBSSettings.FortuneWheelItemSets,
-            StripLevel.UNDERWEAR,
-            StripLevel.UNDERWEAR,
-            enableFlags(DEFAULT_FLAGS.map(clone), [0, 1, 2, 3, 4, 5]),
-            false,
-            false,
-        ),
-        new FWItemSet(
-            "Mummification",
-            FORTUNE_WHEEL_ITEMS.mummy,
-            Player.MBSSettings.FortuneWheelItemSets,
-            StripLevel.CLOTHES,
-            StripLevel.UNDERWEAR,
-            enableFlags(DEFAULT_FLAGS.map(clone), [3]),
-            false,
-            false,
-        ),
-        new FWItemSet(
-            "Bondage Maid",
-            FORTUNE_WHEEL_ITEMS.maid,
-            Player.MBSSettings.FortuneWheelItemSets,
-            StripLevel.UNDERWEAR,
-            StripLevel.UNDERWEAR,
-            enableFlags(DEFAULT_FLAGS.map(clone), [0, 1, 2, 3]),
-            false,
-            false,
-        ),
-        new FWItemSet(
-            "Petrification",
-            FORTUNE_WHEEL_ITEMS.statue,
-            Player.MBSSettings.FortuneWheelItemSets,
-            StripLevel.UNDERWEAR,
-            StripLevel.UNDERWEAR,
-            enableFlags(DEFAULT_FLAGS.map(clone), [0, 1, 2, 3]),
-            false,
-            false,
-            statueCopyColors,
-        ),
-    ]);
-    FORTUNE_WHEEL_ITEM_SETS.forEach(itemSet => itemSet.register(false));
-    FORTUNE_WHEEL_OPTIONS_BASE = Object.freeze(WheelFortuneOption.filter(i => !i.Custom));
-    FORTUNE_WHEEL_DEFAULT_BASE = WheelFortuneDefault;
-    pushMBSSettings([SettingsType.SHARED]);
 
     MBS_MOD_API.hookFunction("WheelFortuneLoad", 11, (args, next) => {
         fortuneWheelState.initialize();
@@ -950,4 +900,58 @@ waitFor(settingsMBSLoaded).then(() => {
     });
 
     fortuneWheelState = new FWScreenProxy();
+
+    waitFor(settingsMBSLoaded).then(() => {
+        logger.log("Initializing wheel of fortune module");
+
+        // Load and register the default MBS item sets
+        FORTUNE_WHEEL_ITEMS = generateItems();
+        FORTUNE_WHEEL_ITEM_SETS = Object.freeze([
+            new FWItemSet(
+                "PSO Bondage",
+                FORTUNE_WHEEL_ITEMS.leash_candy,
+                Player.MBSSettings.FortuneWheelItemSets,
+                StripLevel.UNDERWEAR,
+                StripLevel.UNDERWEAR,
+                enableFlags(DEFAULT_FLAGS.map(clone), [0, 1, 2, 3, 4, 5]),
+                false,
+                false,
+            ),
+            new FWItemSet(
+                "Mummification",
+                FORTUNE_WHEEL_ITEMS.mummy,
+                Player.MBSSettings.FortuneWheelItemSets,
+                StripLevel.CLOTHES,
+                StripLevel.UNDERWEAR,
+                enableFlags(DEFAULT_FLAGS.map(clone), [3]),
+                false,
+                false,
+            ),
+            new FWItemSet(
+                "Bondage Maid",
+                FORTUNE_WHEEL_ITEMS.maid,
+                Player.MBSSettings.FortuneWheelItemSets,
+                StripLevel.UNDERWEAR,
+                StripLevel.UNDERWEAR,
+                enableFlags(DEFAULT_FLAGS.map(clone), [0, 1, 2, 3]),
+                false,
+                false,
+            ),
+            new FWItemSet(
+                "Petrification",
+                FORTUNE_WHEEL_ITEMS.statue,
+                Player.MBSSettings.FortuneWheelItemSets,
+                StripLevel.UNDERWEAR,
+                StripLevel.UNDERWEAR,
+                enableFlags(DEFAULT_FLAGS.map(clone), [0, 1, 2, 3]),
+                false,
+                false,
+                statueCopyColors,
+            ),
+        ]);
+        FORTUNE_WHEEL_ITEM_SETS.forEach(itemSet => itemSet.register(false));
+        FORTUNE_WHEEL_OPTIONS_BASE = Object.freeze(WheelFortuneOption.filter(i => !i.Custom));
+        FORTUNE_WHEEL_DEFAULT_BASE = WheelFortuneDefault;
+        pushMBSSettings([SettingsType.SHARED]);
+    });
 });

--- a/src/fortune_wheel/fortune_wheel_command.ts
+++ b/src/fortune_wheel/fortune_wheel_command.ts
@@ -11,6 +11,7 @@ import {
     MBSObjectScreen,
     ExitAction,
 } from "../screen_abc";
+import { byteToKB } from "../settings";
 
 export class FWCommandScreen extends MBSObjectScreen<FWCommand> {
     static readonly screen = "MBS_FWCommandScreen";
@@ -41,7 +42,7 @@ export class FWCommandScreen extends MBSObjectScreen<FWCommand> {
             {
                 coords: [1610, 60, 90, 90],
                 next: () => {
-                    if (this.settings.isValid(this.index)) {
+                    if (this.settings.isValid(this.index) && this.hasStorageSpace()) {
                         this.exit(false, ExitAction.SAVE);
                     }
                 },
@@ -92,6 +93,10 @@ export class FWCommandScreen extends MBSObjectScreen<FWCommand> {
             acceptDisabled = true;
             acceptColor = "Gray";
             acceptDescription += (this.settings.name === null) ? ": Missing name" : ": Duplicate name";
+        } else if (!this.hasStorageSpace()) {
+            acceptDisabled = true;
+            acceptColor = "Gray";
+            acceptDescription = `Max allowed OnlineSharedSettings storage size exceeded (${byteToKB(this.dataSize.value)} / ${byteToKB(this.dataSize.max)} KB)`;
         }
         DrawButton(1610, 60, 90, 90, "", acceptColor, "Icons/Accept.png", acceptDescription, acceptDisabled);
         ElementPosition("MBSname", 900, 500, 900, 64);

--- a/src/fortune_wheel/fortune_wheel_item_set.ts
+++ b/src/fortune_wheel/fortune_wheel_item_set.ts
@@ -9,6 +9,7 @@ import {
     FWItemSet,
 } from "../common_bc";
 import { MBSScreen, MBSObjectScreen, ExitAction } from "../screen_abc";
+import { byteToKB } from "../settings";
 
 import { toItemBundles } from "./item_bundle";
 import { fortuneWheelEquip, StripLevel, getStripCondition } from "./equipper";
@@ -126,7 +127,7 @@ export class FWItemSetScreen extends MBSObjectScreen<FWItemSet> {
             {
                 coords: [1610, 60, 90, 90],
                 next: () => {
-                    if (this.settings.isValid(this.index)) {
+                    if (this.settings.isValid(this.index) && this.hasStorageSpace()) {
                         this.exit(false, ExitAction.SAVE);
                     }
                 },
@@ -288,6 +289,10 @@ export class FWItemSetScreen extends MBSObjectScreen<FWItemSet> {
             } else {
                 acceptDescription += ": Duplicate name";
             }
+        } else if (!this.hasStorageSpace()) {
+            acceptDisabled = true;
+            acceptColor = "Gray";
+            acceptDescription = `Max allowed OnlineSharedSettings storage size exceeded (${byteToKB(this.dataSize.value)} / ${byteToKB(this.dataSize.max)} KB)`;
         }
         DrawButton(1610, 60, 90, 90, "", acceptColor, "Icons/Accept.png", acceptDescription, acceptDisabled);
         DrawCharacter(this.preview, 300, 175, 0.78, false);

--- a/src/fortune_wheel/fortune_wheel_select.ts
+++ b/src/fortune_wheel/fortune_wheel_select.ts
@@ -1,10 +1,12 @@
 /** Selection screen for custom wheel of fortune options */
 
+import { range } from "lodash-es";
+
 import { LoopIterator, logger } from "../common";
 import { MBS_MAX_SETS, FWItemSet, FWCommand } from "../common_bc";
 import { MBSScreen } from "../screen_abc";
-
 import { parseFWObjects, unpackSettings } from "../settings";
+
 import { FWCommandScreen } from "./fortune_wheel_command";
 import { FWItemSetScreen } from "./fortune_wheel_item_set";
 
@@ -60,16 +62,12 @@ export class FWSelectScreen extends MBSScreen {
     readonly pageSelector: LoopIterator<PageStruct>;
     readonly wheelStruct: WheelStruct;
     readonly character: Character;
-    readonly start = Object.freeze({
-        X: 250,
-        Y: 200,
-    });
-    readonly spacing = Object.freeze({
-        X: 800,
-        Y: 90,
-    });
-    get wheelList() {
-        return this.wheelStruct[this.pageSelector.value.field].slice(...this.pageSelector.value.slice);
+
+    /** A record containing element names mapped to a set of UI functions */
+    readonly elements: Readonly<Record<string, UIElement>>;
+
+    get page() {
+        return this.pageSelector.value.index;
     }
 
     constructor(parent: MBSScreen | null, wheelStruct: WheelStruct, character: Character) {
@@ -106,69 +104,136 @@ export class FWSelectScreen extends MBSScreen {
         ]);
         this.wheelStruct = wheelStruct;
         this.character = character;
+
+        const isPlayer = this.character.IsPlayer();
+        this.elements = Object.freeze({
+            Header: {
+                coords: [1000, 105, 0, 0],
+                run: (x, y) => {
+                    let header = `Select custom wheel of fortune ${this.pageSelector.value.name}`;
+                    if (!isPlayer) {
+                        const name = this.character.Nickname ?? this.character.Name;
+                        header = `Select ${name}'s custom wheel of fortune ${this.pageSelector.value.name}`;
+                    }
+                    DrawText(header, x, y, "Black");
+                },
+            },
+            Exit: {
+                coords: [1830, 60, 90, 90],
+                run: (...coords) => {
+                    DrawButton(...coords, "", "White", "Icons/Exit.png", "Exit");
+                },
+                click: () => {
+                    this.exit();
+                },
+            },
+            Next: {
+                coords: [1720, 60, 90, 90],
+                run: (...coords) => {
+                    DrawButton(...coords, "", "White", "Icons/Next.png", this.pageSelector.next(false).name);
+                },
+                click: () => {
+                    this.pageSelector.next();
+                },
+            },
+            Prev: {
+                coords: [1610, 60, 90, 90],
+                run: (...coords) => {
+                    DrawButton(...coords, "", "White", "Icons/Prev.png", this.pageSelector.previous(false).name);
+                },
+                click: () => {
+                    this.pageSelector.previous();
+                },
+            },
+            ...this.#generateUIElements(),
+        });
+    }
+
+    #generateUIElements(): Record<string, UIElement> {
+        const isPlayer = this.character.IsPlayer();
+        const i_per_row = 8;
+        const i_per_page = i_per_row * 2;
+        const wheelIndices = this.pageSelector.list.flatMap(({ field, slice }, page) => {
+            const list: (null | FWItemSet | FWCommand)[] = this.wheelStruct[field].slice(...slice);
+            return range(list.length).map(i => [page, field, slice[0] + i] as const);
+        });
+
+        return Object.fromEntries(wheelIndices.flatMap(([page, fieldName, i]) => {
+            const x = 450 + ((i_per_row > (i % i_per_page)) ? 0 : 750);
+            const y = 200 + (i % i_per_row) * 90;
+            return [
+                [
+                    `Checkbox${fieldName}${i}}`,
+                    {
+                        page,
+                        coords: [x, y, 64, 64],
+                        run: (...coords) => {
+                            const wheelSet = this.wheelStruct[fieldName][i];
+                            const checkboxDisabled = !isPlayer ? true : wheelSet === null;
+                            DrawCheckbox(...coords, "", !(wheelSet?.hidden ?? true), checkboxDisabled);
+                        },
+                        click: () => {
+                            const wheelSet = this.wheelStruct[fieldName][i];
+                            if (wheelSet !== null && isPlayer) {
+                                wheelSet.hidden = !wheelSet.hidden;
+                            }
+                        },
+                    },
+                ],
+                [
+                    `Button${fieldName}${i}`,
+                    {
+                        page,
+                        coords: [x + 100, y, 550, 64],
+                        run: (...coords) => {
+                            const wheelSet = this.wheelStruct[fieldName][i];
+                            const buttonDisabled = !isPlayer && wheelSet === null;
+                            let name = wheelSet?.name ?? "Empty";
+                            if (name.length > 50) {
+                                name = `${name.slice(0, 50)}...`;
+                            }
+                            DrawButton(
+                                ...coords, `${i + this.pageSelector.value.slice[0]}: ${name}`,
+                                buttonDisabled ? "Gray" : "White", "", "", buttonDisabled,
+                            );
+                        },
+                        click: () => {
+                            const wheelSet = this.wheelStruct[fieldName][i];
+                            const buttonDisabled = !isPlayer && wheelSet === null;
+                            if (!buttonDisabled) {
+                                const subScreen: FWItemSetScreen | FWCommandScreen = new this.pageSelector.value.screenType(
+                                    this,
+                                    <any>this.wheelStruct[this.pageSelector.value.field],
+                                    i,
+                                    this.character,
+                                );
+                                this.children.set(subScreen.screen, subScreen);
+                                subScreen.load();
+                            }
+                        },
+                    },
+                ],
+            ];
+        }));
     }
 
     run(): void {
-        const isPlayer = this.character.IsPlayer();
-        let header = `Select custom wheel of fortune ${this.pageSelector.value.name}`;
-        if (!isPlayer) {
-            const name = this.character.Nickname ?? this.character.Name;
-            header = `Select ${name}'s custom wheel of fortune ${this.pageSelector.value.name}`;
-        }
-        DrawText(header, 1000, 105, "Black");
-        DrawButton(1830, 60, 90, 90, "", "White", "Icons/Exit.png", "Exit");
-        DrawButton(1720, 60, 90, 90, "", "White", "Icons/Next.png", this.pageSelector.next(false).name);
-        DrawButton(1610, 60, 90, 90, "", "White", "Icons/Prev.png", this.pageSelector.previous(false).name);
-
-        const i_per_row = 8;
-        for (const [i, wheelSet] of this.wheelList.entries()) {
-            const y = this.start.Y + (i % i_per_row) * this.spacing.Y;
-            const dx = (i_per_row > i) ? 0 : this.spacing.X;
-            const checkboxDisabled = !isPlayer ? true : wheelSet === null;
-            const buttonDisabled = !isPlayer && wheelSet === null;
-            let name = wheelSet?.name ?? "Empty";
-            if (name.length > 50) {
-                name = `${name.slice(0, 50)}...`;
+        Object.values(this.elements).forEach((e) => {
+            if ((e.page ?? this.page) === this.page) {
+                e.run(...e.coords);
             }
-            DrawCheckbox(this.start.X + dx, y, 64, 64, "", !(wheelSet?.hidden ?? true), checkboxDisabled);
-            DrawButton(
-                this.start.X + 100 + dx, y, 600, 64, `${i + this.pageSelector.value.slice[0]}: ${name}`,
-                buttonDisabled ? "Gray" : "White", "", "", buttonDisabled,
-            );
-        }
+        });
     }
 
-    click(): null | FWCommandScreen | FWItemSetScreen {
-        if (MouseIn(1830, 60, 90, 90)) {
-            this.exit();
-            return null;
-        } else if (MouseIn(1720, 60, 90, 90)) {
-            this.pageSelector.next();
-            return null;
-        } else if (MouseIn(1610, 60, 90, 90)) {
-            this.pageSelector.previous();
-            return null;
-        }
-
-        const isPlayer = this.character.IsPlayer();
-        const i_per_row = 8;
-        for (const [i, wheelSet] of this.wheelList.entries()) {
-            const y = this.start.Y + (i % i_per_row) * this.spacing.Y;
-            const dx = (i_per_row > i) ? 0 : this.spacing.X;
-            const buttonDisabled = !isPlayer && wheelSet === null;
-            if (MouseIn(this.start.X + dx, y, 64, 64) && wheelSet !== null && isPlayer) {
-                wheelSet.hidden = !wheelSet.hidden;
-                return null;
-            } else if (MouseIn(this.start.X + 100 + dx, y, 600, 64) && !buttonDisabled) {
-                const subScreen: FWItemSetScreen | FWCommandScreen = new this.pageSelector.value.screenType(
-                    this, <any>this.wheelStruct[this.pageSelector.value.field], i + this.pageSelector.value.slice[0], this.character,
-                );
-                this.children.set(subScreen.screen, subScreen);
-                subScreen.load();
-                return subScreen;
+    click(event: MouseEvent | TouchEvent) {
+        return Object.values(this.elements).some((e) => {
+            if (e.click && (e.page ?? this.page) === this.page && MouseIn(...e.coords)) {
+                e.click(event);
+                return true;
+            } else {
+                return false;
             }
-        }
-        return null;
+        });
     }
 
     exit(): void {

--- a/src/fortune_wheel/item_bundle.ts
+++ b/src/fortune_wheel/item_bundle.ts
@@ -139,24 +139,6 @@ function sanitizeProperties(asset: Asset, properties?: ItemProperties): ItemProp
     return ret;
 }
 
-/**
- * Shrink the crafted item description down to a minimum set of LSCG keywords
- * @param description The to-be parsed description
- * @returns The parsed description
- */
-function minifyDescription(description?: null | string) {
-    if (!description || typeof LSCG === "undefined") {
-        return "";
-    }
-
-    const keywords = [
-        ...(LSCG?.NetgunKeywords() ?? []),
-        ...(LSCG?.DrugKeywords() ?? []),
-        ...(LSCG?.CraftableItemSpellNames() ?? []),
-    ];
-    return keywords.filter(i => description.includes(i)).join(" ");
-}
-
 /** A map with various {@link Asset} validation checks for {@link fromItemBundles}. */
 const UNSUPPORTED_ASSET_CHECKS = Object.freeze(new Map([
     ["Unknown asset", (asset: null | Asset) => asset == null],
@@ -198,7 +180,6 @@ export function fromItemBundle(
                 TypeRecord: undefined,
                 OverridePriority: null,
                 Lock: "",
-                Description: minifyDescription(item.Craft.Description),
             },
         );
         CraftingValidate(craft, asset, false);

--- a/src/fortune_wheel/preset_screen.ts
+++ b/src/fortune_wheel/preset_screen.ts
@@ -1,7 +1,5 @@
-import { clamp } from "lodash-es";
-
 import { fromEntries, validateInt, waitFor } from "../common";
-import { sanitizeWheelFortuneIDs, MBS_MAX_SETS, FWItemSet, bcLoaded } from "../common_bc";
+import { sanitizeWheelFortuneIDs, MBS_MAX_SETS, FWItemSet, bcLoaded, drawHeaderedTooltip } from "../common_bc";
 import { MBSScreen } from "../screen_abc";
 import { pushMBSSettings, SettingsType } from "../settings";
 
@@ -24,29 +22,6 @@ waitFor(bcLoaded).then(() => {
     const csvPath = "Screens/MiniGame/WheelFortune/Text_WheelFortune.csv";
     SCREEN_CACHE = new TextCache(csvPath, "MISSING VALUE FOR TAG: ");
 });
-
-function drawPresetTooltip(x: number, y: number, w: number, tooltip: string[]) {
-    const [header, ...rest] = tooltip;
-    const h = DELTA + rest.length * 48 + (rest.length > 0 ? 16 : 0);
-    x = clamp(x, 0, 2000 - w);
-    y = clamp(y, 0, 1000 - h);
-
-    DrawRect(x, y, w, h, "White");
-    DrawEmptyRect(x, y, w, h, "Black", 2);
-    MainCanvas.beginPath();
-    MainCanvas.moveTo(x, y + DELTA);
-    MainCanvas.lineTo(x + w, y + DELTA);
-    MainCanvas.stroke();
-
-    MainCanvas.textBaseline = "middle";
-    DrawTextFit(header, x + (w / 2), y + DELTA / 2, w - 32, "black");
-    MainCanvas.textAlign = "left";
-    MainCanvas.font = '30px "Arial", sans-serif';
-    rest.forEach((str, i) => DrawText(str, x + 16, y + DELTA + 8 + 24 + i * 48, "black"));
-    MainCanvas.textAlign = "center";
-    MainCanvas.font = '36px "Arial", sans-serif';
-    MainCanvas.textBaseline = "top";
-}
 
 export class WheelPresetScreen extends MBSScreen {
     static readonly background = "Sheet";
@@ -246,7 +221,7 @@ export class WheelPresetScreen extends MBSScreen {
             }
         }
 
-        return fromEntries(Object.values(optionRecord).map(({ ids, prefix, suffix }, i) => {
+        return fromEntries(Object.values(optionRecord).map(({ ids, prefix, suffix }, i): [string, UIElement] => {
             const x = gridSpec.xOffset + Math.floor(i / OPTIONS_PER_ROW) * gridSpec.xDelta;
             const y = gridSpec.yOffset + (i % OPTIONS_PER_ROW) * gridSpec.yDelta;
             return [
@@ -260,7 +235,7 @@ export class WheelPresetScreen extends MBSScreen {
                             DrawHoverElements.push(() => {
                                 const tooltip = [prefix, ...suffix.filter((_, i) => this.activePreset.ids.has(ids[i]))];
                                 DrawRect(x + 3, y + 3, w - 6, h - 6, "rgba(0,0,0,0.5)");
-                                drawPresetTooltip(x - (DELTA * 7), y - DELTA, DELTA * 7 - 12, tooltip);
+                                drawHeaderedTooltip(x - (DELTA * 7), y - DELTA, DELTA * 7 - 12, DELTA, tooltip);
                             });
                         }
                     },
@@ -304,7 +279,7 @@ export class WheelPresetScreen extends MBSScreen {
                             const tooltip = [`${prefix}: ${middle}`, ...suffix];
 
                             DrawRect(x + 3, y + 3, w - 6, h - 6, "rgba(0,0,0,0.5)");
-                            drawPresetTooltip(x - (DELTA * 7), y - DELTA, DELTA * 7 - 12, tooltip);
+                            drawHeaderedTooltip(x - (DELTA * 7), y - DELTA, DELTA * 7 - 12, DELTA, tooltip);
                         }
                     },
                 },

--- a/src/fortune_wheel/preset_screen.ts
+++ b/src/fortune_wheel/preset_screen.ts
@@ -1,7 +1,7 @@
 import { clamp } from "lodash-es";
 
 import { fromEntries, validateInt, waitFor } from "../common";
-import { sanitizeWheelFortuneIDs, MBS_MAX_SETS, FWItemSet } from "../common_bc";
+import { sanitizeWheelFortuneIDs, MBS_MAX_SETS, FWItemSet, bcLoaded } from "../common_bc";
 import { MBSScreen } from "../screen_abc";
 import { pushMBSSettings, SettingsType } from "../settings";
 
@@ -20,7 +20,7 @@ interface GridSpec {
 
 /** A {@link TextCache} cache for the `MiniGame/WheelFortune` screen */
 let SCREEN_CACHE: TextCache;
-waitFor(() => typeof MainCanvas !== "undefined").then(() => {
+waitFor(bcLoaded).then(() => {
     const csvPath = "Screens/MiniGame/WheelFortune/Text_WheelFortune.csv";
     SCREEN_CACHE = new TextCache(csvPath, "MISSING VALUE FOR TAG: ");
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 
 import { waitFor, MBS_MOD_API, logger } from "./common";
 import { validateBCVersion, validateHookHashes } from "./sanity_checks";
-import { settingsMBSLoaded } from "./common_bc";
+import { bcLoaded } from "./common_bc";
 import { toItemBundles as _toItemBundles } from "./fortune_wheel";
 import { unpackSettings as _unpackSettings } from "./settings";
 import { wheelOutfits, getDebug, API_VERSION } from "./api";
@@ -23,8 +23,8 @@ export {
 };
 
 logger.log(`Initializing MBS version ${MBS_VERSION}`);
-waitFor(() => typeof GameVersion === "string" && GameVersion !== "R0").then(() => validateBCVersion(GameVersion));
-waitFor(settingsMBSLoaded).then(validateHookHashes);
+waitFor(() => bcLoaded(false)).then(() => validateBCVersion(GameVersion));
+waitFor(bcLoaded).then(validateHookHashes);
 
 import "./window_register";
 import "./crafting";

--- a/src/new_items_screen/index.ts
+++ b/src/new_items_screen/index.ts
@@ -1,4 +1,5 @@
 import { MBS_MOD_API, waitFor, logger } from "../common";
+import { bcLoaded } from "../common_bc";
 
 import { NEW_ASSETS_VERSION, NewItemsScreen, MainHallProxy, itemScreenDummy } from "./screen";
 
@@ -7,7 +8,7 @@ export {
     NEW_ASSETS_VERSION,
 };
 
-waitFor(() => typeof MainCanvas !== "undefined").then(() => {
+waitFor(bcLoaded).then(() => {
     logger.log("Initializing new item screen hooks");
 
     const mainHallState = new MainHallProxy();

--- a/src/new_items_screen/screen.ts
+++ b/src/new_items_screen/screen.ts
@@ -3,6 +3,7 @@ import { inRange, omit } from "lodash-es";
 
 import { keys, entries, fromEntries, LoopIterator, waitFor, logger } from "../common";
 import { MBSScreen, ScreenProxy } from "../screen_abc";
+import { bcLoaded } from "../common_bc";
 
 /**
  * Adapted from {@link CommonGenerateGridParameters}.
@@ -64,7 +65,7 @@ const NEW_ASSETS: Record<AssetKey, Asset> = {};
 /** A record mapping {@link Asset.BuyGroup} names to the (adjusted) cost of each asset plus a list of all minified assets */
 const BUY_GROUPS: Record<string, { readonly money: number, readonly assets: ItemBundle[] }> = {};
 
-waitFor(() => typeof MainCanvas !== "undefined").then(() => {
+waitFor(bcLoaded).then(() => {
     const result = GameVersionFormat.exec(GameVersion);
     if (result == null) {
         logger.error(`Invalid BC version: "${GameVersion}"`);

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,6 +1,7 @@
 import { pushMBSSettings, SettingsType, getChangeLogURL, unpackSettings, parseFWObjects } from "./settings";
 import { MBSPreferenceScreen } from "./settings_screen";
 import { ResetScreen } from "./reset_screen";
+import { getStorageElement } from "./storage_usage";
 
 export {
     MBSPreferenceScreen,
@@ -10,4 +11,5 @@ export {
     getChangeLogURL,
     unpackSettings,
     parseFWObjects,
+    getStorageElement,
 };

--- a/src/settings/index.ts
+++ b/src/settings/index.ts
@@ -1,7 +1,7 @@
 import { pushMBSSettings, SettingsType, getChangeLogURL, unpackSettings, parseFWObjects } from "./settings";
 import { MBSPreferenceScreen } from "./settings_screen";
 import { ResetScreen } from "./reset_screen";
-import { getStorageElement } from "./storage_usage";
+import { getStorageElement, measureDataSize, MAX_DATA, byteToKB } from "./storage_usage";
 
 export {
     MBSPreferenceScreen,
@@ -12,4 +12,7 @@ export {
     unpackSettings,
     parseFWObjects,
     getStorageElement,
+    measureDataSize,
+    MAX_DATA,
+    byteToKB,
 };

--- a/src/settings/settings_screen.ts
+++ b/src/settings/settings_screen.ts
@@ -1,5 +1,5 @@
 import { MBS_MOD_API, waitFor } from "../common";
-import { settingsMBSLoaded } from "../common_bc";
+import { bcLoaded } from "../common_bc";
 import { MBSScreen, ScreenProxy } from "../screen_abc";
 import { FWSelectScreen, loadFortuneWheelObjects } from "../fortune_wheel";
 import { NewItemsScreen, NEW_ASSETS_VERSION } from "../new_items_screen";
@@ -184,7 +184,7 @@ MBS_MOD_API.hookFunction("PreferenceClick", 0, (args, next) => {
 
 let preferenceState: PreferenceScreenProxy;
 
-waitFor(settingsMBSLoaded).then(() => {
+waitFor(bcLoaded).then(() => {
     (<string[]>PreferenceSubscreenList).push(
         MBSPreferenceScreen.screen,
     );

--- a/src/settings/storage_usage.ts
+++ b/src/settings/storage_usage.ts
@@ -1,13 +1,19 @@
-import { clamp, sumBy } from "lodash-es";
+import { clamp } from "lodash-es";
+
+import { drawHeaderedTooltip } from "../common_bc";
 
 /**
  * The maximum allowed single-packet byte-size before the BC server says no.
  * @see {@link https://github.com/Ben987/Bondage-Club-Server/blob/a23c73bcd85eddc4cbf41bff43dd31823c15fab7/app.js#L34}
  */
-const MAX_DATA = 180_000;
+export const MAX_DATA = 180_000;
 
-/** Return an upper bound of the passed object's byte-size. */
-function measureDataSize(data: unknown): Record<string, number> {
+/**
+ * Return an upper bound of the passed object's byte-size.
+ * @param data The object whose size is to-be measured on a key-by-key basis
+ * @returns A record mapping all keys in `data` to their respective byte size or `NaN` if it cannot be determined
+ */
+export function measureDataSize(data: unknown): Record<string, number> {
     const addonSize: Record<string, number> = {};
     const dataRecord = CommonIsObject(data) ? data : {};
     for (const [key, value] of Object.entries(dataRecord)) {
@@ -21,40 +27,74 @@ function measureDataSize(data: unknown): Record<string, number> {
     return addonSize;
 }
 
-export function getStorageElement(character: Character, coords: RectTuple): UIElement {
-    const nBytesRecord = measureDataSize(character.OnlineSharedSettings);
-    const nBytes = sumBy(Object.values(nBytesRecord), (i) => Number.isNaN(i) ? 0 : i);
-    const heightFrac = clamp(nBytes / MAX_DATA, 0, 1);
+/** Convert B to KB with up to one decimal digit. */
+export function byteToKB(nByte: number) {
+    return Math.round(nByte / 100) / 10;
+}
 
-    const nColorHalfID = 192;
-    const nColorHalf = nColorHalfID.toString(16);
-    const topColorID = clamp((2 * heightFrac - 1) / 0.9, 0, 1) * 2 * nColorHalfID;
-    const topColor = (topColorID % nColorHalfID).toString(16);
-    const topColor2 = heightFrac >= 0.5 ? `#${nColorHalf}${topColor}00` : `#${topColor}${nColorHalf}00`;
+export function getStorageElement(
+    this: { dataSize: DataSize },
+    coords: RectTuple,
+): UIElement {
+    const nColorHalfID = 216;
+    const nColorHalf = nColorHalfID.toString(16).padStart(2, "0");
+
     return {
         coords: [...coords],
         run: (x, y, w, h) => {
-            MainCanvas.beginPath();
-            MainCanvas.rect(x - 3, y - 3, w + 6, h + 6);
-            MainCanvas.lineWidth = 3;
-            MainCanvas.strokeStyle = "Black";
+            const heightFrac = clamp(this.dataSize.value / MAX_DATA, 0, 1);
+            const topColorID = Math.round(clamp((heightFrac - 0.2) / 0.6, 0, 1) * 2 * nColorHalfID);
+            const topColor = (topColorID % nColorHalfID).toString(16).padStart(2, "0");
+            const topColor2 = (topColorID >= nColorHalfID) ? `#${nColorHalf}${topColor}00` : `#${topColor}${nColorHalf}00`;
+
             if (heightFrac >= 0.9) {
-                MainCanvas.shadowBlur = 10;
+                MainCanvas.save();
+                MainCanvas.beginPath();
+                MainCanvas.fillStyle = "Red";
+                MainCanvas.shadowBlur = 6;
                 MainCanvas.shadowColor = "Red";
+                MainCanvas.fillRect(x - 3, y - 3, w + 6, h + 6);
+                MainCanvas.fill();
+
+                MainCanvas.restore();
             }
-            MainCanvas.stroke();
             DrawRect(x, y, w, h, "White");
 
-            const offset = h * heightFrac;
-            const grd2 = MainCanvas.createLinearGradient(0, h - offset, 0, 0);
-            grd2.addColorStop(0, `#00${nColorHalfID}00`);
-            grd2.addColorStop(clamp(0.5 / heightFrac, 0, 1), `#00${nColorHalfID}00`);
-            grd2.addColorStop(1, topColor2);
-            MainCanvas.fillStyle = grd2;
-            MainCanvas.fillRect(x, y + offset, w, h - offset);
+            const nKBTotal = clamp(byteToKB(this.dataSize.value), 0, 9999);
+            DrawText(`${nKBTotal} / ${MAX_DATA / 1000} KB`, x + (w / 2), y + h + 58, "Black");
+
+            const grad = MainCanvas.createLinearGradient(0, y + h, 0, y);
+            grad.addColorStop(0, `#00${nColorHalf}00`);
+            grad.addColorStop(clamp(0.2 / heightFrac, 0, 1), `#00${nColorHalf}00`);
+            grad.addColorStop(clamp(0.8 / heightFrac, 0, 1), topColor2);
+            grad.addColorStop(1, topColor2);
+            MainCanvas.fillStyle = grad;
+            MainCanvas.fillRect(x, y + h * (1 - heightFrac), w, h * heightFrac);
+
+            DrawEmptyRect(x, y, w, h, "Black", 2);
+            MainCanvas.beginPath();
+            MainCanvas.lineWidth = 2;
+            MainCanvas.strokeStyle = "Black";
+            MainCanvas.moveTo(x, y + h * (1 - heightFrac));
+            MainCanvas.lineTo(x + w, y + h * (1 - heightFrac));
+            MainCanvas.stroke();
 
             if (MouseIn(x, y, w, h)) {
-                DrawButtonHover(x, y, w, h, "Lorem Ipsum");
+                const entries = Object.entries(this.dataSize.valueRecord).map(([k, v]) => {
+                    if (k.length > 28) {
+                        k = `${k.slice(0, 25)}...`;
+                    }
+                    const nKB = Number.isNaN(v) ? "Unknown" : `${byteToKB(v)} KB`;
+                    return [k, nKB] as const;
+                });
+                DrawHoverElements.push(() => {
+                    drawHeaderedTooltip(x + w + 36, y - 64, 550, 64, ["OnlineSharedSettings Data Usage", ...entries.map(i => i[0])]);
+                    MainCanvas.save();
+                    MainCanvas.font = '30px "Arial", sans-serif';
+                    MainCanvas.textAlign = "right";
+                    entries.forEach(([_, nKB], i) => DrawText(nKB, x + w + 574, y + 8 + 24 + i * 48, "black"));
+                    MainCanvas.restore();
+                });
             }
         },
     };

--- a/src/stub_files/bcs_types.d.ts
+++ b/src/stub_files/bcs_types.d.ts
@@ -229,3 +229,15 @@ interface WheelPreset {
     readonly name: string,
     readonly ids: string,
 }
+
+/** The maximum and actually used size of {@link Character.OnlineSharedSettings} */
+interface DataSize {
+    /** The currently used data size in bytes */
+    value: number,
+    /** The currently used data size in bytes per key */
+    valueRecord: Record<string, number>;
+    /** The maximum data size in bytes */
+    readonly max: number,
+    /** A safety marigin in the `[0, 1]` interval applied as a factor to `max` */
+    readonly marigin: number,
+}

--- a/src/window_register.ts
+++ b/src/window_register.ts
@@ -1,12 +1,12 @@
 /** Module for managing the {@link globalThis} exporting of MBS functions. */
 
 import { waitFor } from "./common";
-import { settingsMBSLoaded } from "./common_bc";
+import { bcLoaded } from "./common_bc";
 import { FWItemSetScreen, FWCommandScreen, FWSelectScreen, WheelPresetScreen } from "./fortune_wheel";
 import { MBSPreferenceScreen, ResetScreen } from "./settings";
 import { NewItemsScreen } from "./new_items_screen";
 
-waitFor(settingsMBSLoaded).then(() => {
+waitFor(bcLoaded).then(() => {
     const backgrounds = {
         [`${FWItemSetScreen.screen}Background`]: FWItemSetScreen.background,
         [`${FWCommandScreen.screen}Background`]: FWCommandScreen.background,


### PR DESCRIPTION
* Refactor the logic for checking whether BC is properly loaded or not
* Re-enable the storing of crafted item descriptions in the wheel of fortune, reverting their previous removal in MBS v0.6.22
* Add checks to ensure that MBS does not exceed the 180 KB storage limit for its shared settings, exceeding of which can cause crashes and unstable behavior in BC