### PR TITLE
REL: Version bump: 1.4.6 > 1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MBS Changelog
 
+## 1.4.7
+* Fix the MBS settings menu sometimes requiring two clicks to exit
+* Fix the MBS settings menu locking being incorrectly locked when restrained
+
 ## 1.4.6
 * Use DOM elements for the MBS preference screens
 * Bump the BC mod SDK to 1.2.0

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.4.6.dev0
+// @version      1.4.7.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.4.6
+// @version      1.4.7
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.4.6",
+    "version": "1.4.7",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/settings/settings_screen.tsx
+++ b/src/settings/settings_screen.tsx
@@ -330,7 +330,7 @@ export class MBSPreferenceScreen extends MBSScreen {
 
     exit() {
         const resetScreen = document.getElementById(ID.resetScreen) as HTMLDivElement;
-        if (resetScreen.style.display !== "none") {
+        if (resetScreen.style.display === "block") {
             resetScreen.style.display = "none";
         } else {
             ElementRemove(ID.root);

--- a/src/settings/settings_screen.tsx
+++ b/src/settings/settings_screen.tsx
@@ -291,7 +291,7 @@ export class MBSPreferenceScreen extends MBSScreen {
             [ID.rollCheckbox]: "RollWhenRestrained",
         } as const satisfies Record<string, keyof MBSSettings>;
 
-        const disabled = Player.IsRestrained() && !Player.MBSSettings.RollWhenRestrained;
+        const disabled = Player.IsRestrained() && !Player.MBSSettings.LockedWhenRestrained;
         for (const [id, field] of Object.entries(checkboxes)) {
             const checkbox = document.getElementById(id) as HTMLInputElement;
             checkbox.checked = Player.MBSSettings[field];


### PR DESCRIPTION
* Fix the MBS settings menu sometimes requiring two clicks to exit
* Fix the MBS settings menu locking being incorrectly locked when restrained