### PR TITLE
REL: Version bump: 1.7.7 > 1.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # MBS Changelog
 
+## 1.7.8
+* Backport two R105 bug fixes
+    - [BondageProjects/Bondage-College#5052](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5052): fix `PreferenceSubscreenExtensionsClear()` when the optional unload function is undefined
+    - [BondageProjects/Bondage-College#5055](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5055): Disable layering for locked items that one cannot unlock
+
 ## 1.7.7
 * Drop BC R103 support
 * Fix the screen shape not being passed on to the fortune wheel command screen

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.7.7.dev0
+// @version      1.7.8.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.7.7
+// @version      1.7.8
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.7.7",
+    "version": "1.7.8",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -15,6 +15,58 @@ const BC_NEXT = BC_MIN_VERSION + 1;
 export const backportIDs: Set<number> = new Set();
 
 waitFor(bcLoaded).then(() => {
+    switch (GameVersion) {
+        case "R104": {
+            if (MBS_MOD_API.getOriginalHash("PreferenceSubscreenExtensionsClear") === "BA474ADD") {
+                backportIDs.add(5052);
+                MBS_MOD_API.patchFunction("PreferenceSubscreenExtensionsClear", {
+                    ["PreferenceExtensionsCurrent.unload();"]:
+                        "PreferenceExtensionsCurrent.unload?.();",
+                });
+            }
+
+            if (MBS_MOD_API.getOriginalHash("AppearanceClick") === "4E3937AA") {
+                backportIDs.add(5055);
+                MBS_MOD_API.patchFunction("AppearanceClick", {
+                    ["const asset = CharacterAppearanceNextItem(C, Group.Name, MouseX > 1500);"]:
+                        "const asset = CharacterAppearanceNextItem(C, Group.Name, MouseX > 1410);",
+                });
+            }
+
+            // `patchFunction` doesnt play nice with bound methods, so use a dirty override instead
+            if (MBS_MOD_API.getOriginalHash("Layering._ApplyAssetPriority") === "B738E4DD") {
+                backportIDs.add(5055);
+                Layering._ApplyAssetPriority = function _ApplyAssetPriority(this: typeof Layering, priority: number, defaultPriority: string) {
+                    const old = this.OverridePriority;
+                    if (!Number.isInteger(old)) {
+                        this._UpdateInputColors("asset-priority");
+                    }
+
+                    if (!Number.isNaN(priority) && priority.toString() !== defaultPriority) {
+                        this.OverridePriority = CommonClamp(Math.round(priority), -99, 99);
+                    } else {
+                        // @ts-ignore
+                        this.OverridePriority = undefined;
+                    }
+
+                    if (old !== this.OverridePriority) {
+                        this._CharacterRefresh(this.Character as Character, false, false);
+                    }
+                }.bind(Layering);
+            }
+
+            if (MBS_MOD_API.getOriginalHash("DialogMenuButtonBuild") === "AC1C6466") {
+                backportIDs.add(5055);
+                MBS_MOD_API.patchFunction("DialogMenuButtonBuild", {
+                    ["if (Item != null && !C.IsNpc() && Player.CanInteract()) {"]:
+                        "if (Item != null && !C.IsNpc() && (InventoryItemHasEffect(Item, 'Lock') ? DialogCanUnlock(C, Item) : Player.CanInteract())) {",
+                });
+            }
+
+            break;
+        }
+    }
+
     if (backportIDs.size) {
         logger.log(`Initializing R${BC_NEXT} bug fix backports`, sortBy(Array.from(backportIDs)));
     } else {


### PR DESCRIPTION
* Backport two R105 bug fixes
    - [BondageProjects/Bondage-College#5052](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5052): fix `PreferenceSubscreenExtensionsClear()` when the optional unload function is undefined
    - [BondageProjects/Bondage-College#5055](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5055): Disable layering for locked items that one cannot unlock