### PR TITLE
REL: Version bump: 1.7.21 > 1.7.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MBS Changelog
 
+## v1.7.22
+* Include the new BC EU host URL in the MBS user script
+* Add the ability to create crafted item description with up to 398 "simple" characters (_i.e._ extended ASCII).
+  This functionality can be enabled under `Preferences` > `MBS Settings`.
+  Note that these descriptions will only be legible for MBS users.
+
 ## v1.7.21
 * Drop R106 support
 * Update reported R107 items

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version     1.7.21.dev0
+// @version     1.7.22.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version     1.7.21
+// @version     1.7.22
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.7.21",
+    "version": "1.7.22",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/crafting/index.ts
+++ b/src/crafting/index.ts
@@ -9,7 +9,6 @@ const MBS_SLOT_MAX_ORIGINAL = 160;
 
 /** Control character used for marking extended crafted item descriptions. */
 const EXTENDED_DESCRIPTION_MARKER = "\x00";
-const EXTENDED_DESCRIPTION_ENABLED: boolean = true;
 
 /** A set of all illegal non-control (extended) ASCII character codes. */
 const CHAR_CODE_ILLEGAL = new Set([
@@ -200,7 +199,7 @@ waitFor(bcLoaded).then(() => {
 
     MBS_MOD_API.hookFunction("CraftingKeyUp", 0, (args, next) => {
         if (CraftingSelectedItem && document.getElementById("InputDescription") != null) {
-            if (EXTENDED_DESCRIPTION_ENABLED) {
+            if (Player.MBSSettings.ExtendedCraftingDescription) {
                 CraftingSelectedItem.Description = descriptionEncode(ElementValue("InputDescription"));
             } else {
                 CraftingSelectedItem.Description = ElementValue("InputDescription");

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -194,6 +194,7 @@ function parseProtoSettings(s: MBSProtoSettings): SettingsStatus.Base {
         AlternativeGarbling: [],
         DropTrailing: [],
         GarblePerSyllable: [],
+        ExtendedCraftingDescription: [],
     };
 
     const scalars = {
@@ -203,6 +204,7 @@ function parseProtoSettings(s: MBSProtoSettings): SettingsStatus.Base {
         AlternativeGarbling: false,
         DropTrailing: false,
         GarblePerSyllable: false,
+        ExtendedCraftingDescription: false,
     } satisfies { [k in keyof typeof err]?: number | boolean | string };
 
     for (const [field, defaultValue] of entries(scalars as Record<keyof typeof scalars, unknown>)) {
@@ -226,6 +228,7 @@ function parseProtoSettings(s: MBSProtoSettings): SettingsStatus.Base {
         AlternativeGarbling: scalars.AlternativeGarbling,
         DropTrailing: scalars.DropTrailing,
         GarblePerSyllable: scalars.GarblePerSyllable,
+        ExtendedCraftingDescription: scalars.ExtendedCraftingDescription,
     };
     if (settings.AlternativeGarbling) {
         garblingJSON.init();
@@ -322,6 +325,7 @@ export function clearMBSSettings(): void {
         AlternativeGarbling: false,
         DropTrailing: false,
         GarblePerSyllable: false,
+        ExtendedCraftingDescription: false,
     });
 
     ServerAccountUpdate.QueueData({

--- a/src/settings/settings_screen.tsx
+++ b/src/settings/settings_screen.tsx
@@ -169,6 +169,15 @@ export class MBSPreferenceScreen extends MBSScreen {
                         Interpolate between the three alternative garbling levels, allowing for a more gradual increase
                         in garbling strength (on a syllable by syllable basis) as the gag level increases
                     </div>
+
+                    <h2>Crafting settings</h2>
+                    <div class="mbs-preference-settings-pair">
+                        <input type="checkbox" data-field="ExtendedCraftingDescription" onClick={this.#boolSwitch.bind(this)}/>
+                        <span>
+                            Allow crafted item descriptions to use up to 398 "simple" characters (<i>e.g.</i> no smilies or other non-ASCII characters).<br />
+                            WARNING: Note that these descriptions are only legible for those with MBS enabled (including yourself).
+                        </span>
+                    </div>
                 </div>
 
                 <div id={ID.miscGrid}>

--- a/src/stub_files/bcs_types.d.ts
+++ b/src/stub_files/bcs_types.d.ts
@@ -148,6 +148,8 @@ interface MBSProtoSettings {
     DropTrailing?: boolean;
     /** Whether to interpolate between gag levels using different garbling tables */
     GarblePerSyllable?: boolean;
+    /** Whether to allow up to 398 extended ASCII characters in a crafted item description */
+    ExtendedCraftingDescription?: boolean;
 }
 
 /** The MBS settings */
@@ -175,6 +177,8 @@ interface MBSSettings extends Record<Exclude<keyof MBSProtoSettings, "FortuneWhe
     DropTrailing: boolean;
     /** Whether to interpolate between gag levels using different garbling tables */
     GarblePerSyllable: boolean;
+    /** Whether to allow up to 398 extended ASCII characters in a crafted item description */
+    ExtendedCraftingDescription: boolean;
 }
 
 /** An interface for representing clickable buttons */


### PR DESCRIPTION
* Include the new BC EU host URL in the MBS user script
* Add the ability to create crafted item description with up to 398 "simple" characters (_i.e._ extended ASCII).
  This functionality can be enabled under `Preferences` > `MBS Settings`.
  Note that these descriptions will only be legible for MBS users.