### PR TITLE
REL: Version bump: 1.7.26 > 1.7.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # MBS Changelog
 
+## v1.7.27
+* Drop R107 support
+* Ensure that exiting the MBS preference screen returns one to the preference extension subscreen
+* Backport two R109 changes:
+    - [BondageProjects/Bondage-College#5205](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5205): Take `Asset.CraftGroup` into account when sorting crafted items
+    - [BondageProjects/Bondage-College#5207](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5207): Fix two crafting screen bugs
+    - [BondageProjects/Bondage-College#5208](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5208): Fix the appropriate default color failing to be selected upon creating a new crafted item
+
 ## v1.7.26
 * Add R108Beta1 support
 * Move the MBS preferences from `Preferences > MBS` to `Preferences > Extensions > MBS` starting from R108

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version     1.7.26.dev0
+// @version     1.7.27.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version     1.7.26
+// @version     1.7.27
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.7.26",
+    "version": "1.7.27",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/backport.tsx
+++ b/src/backport.tsx
@@ -16,39 +16,7 @@ export const backportIDs: Set<number> = new Set();
 
 waitFor(bcLoaded).then(() => {
     switch (GameVersion) {
-        case "R107": {
-            break;
-        }
-        case "R108Beta1": {
-            if (
-                MBS_MOD_API.getOriginalHash("PreferenceExit") === "180F0DB5"
-                && MBS_MOD_API.getOriginalHash("PreferenceSubscreenExtensionsExit") === "FF486E53"
-            ) {
-                backportIDs.add(5188);
-                MBS_MOD_API.patchFunction("PreferenceExit", {
-                    "if (!PreferenceSubscreenExit())":
-                        "if (PreferenceSubscreenExit())",
-                });
-                MBS_MOD_API.patchFunction("PreferenceSubscreenExtensionsExit", {
-                    "if (PreferenceExtensionsCurrent.exit()) {":
-                        "if (PreferenceExtensionsCurrent.exit() ?? true) {",
-                });
-
-                const prefSubscreen = PreferenceSubscreens.find(({ name }) => name === "Extensions");
-                if (prefSubscreen) {
-                    prefSubscreen.exit = PreferenceSubscreenExtensionsExit;
-                }
-            }
-
-            if (MBS_MOD_API.getOriginalHash("CraftingLoad") === "AF96A27B") {
-                backportIDs.add(5187);
-                MBS_MOD_API.patchFunction("CraftingLoad", {
-                    'attributes: { id: CraftingID.root, "screen-generated": CurrentScreen },':
-                        'attributes: { id: CraftingID.root, "screen-generated": CurrentScreen, "aria-busy": "true" },',
-                    'parent.setAttribute("data-loaded", true);':
-                        'parent.setAttribute("data-loaded", true); parent.setAttribute("aria-busy", "false");',
-                });
-            }
+        case "R108": {
             break;
         }
     }

--- a/src/backport.tsx
+++ b/src/backport.tsx
@@ -17,6 +17,53 @@ export const backportIDs: Set<number> = new Set();
 waitFor(bcLoaded).then(() => {
     switch (GameVersion) {
         case "R108": {
+            if (
+                MBS_MOD_API.getOriginalHash("CraftingExit") === "FB1A1DB2"
+                && MBS_MOD_API.getOriginalHash("CraftingEventListeners._ClickAccept") === "49327A7A"
+            ) {
+                backportIDs.add(5207);
+
+                MBS_MOD_API.patchFunction("CraftingEventListeners._ClickAccept", {
+                    "CraftingSelectedItem = null;":
+                        ";",
+                    'CraftingModeSet("Slot");':
+                        ";",
+                });
+
+                MBS_MOD_API.hookFunction("CraftingEventListeners._ClickAccept", 0, (args, next) => {
+                    const ret = next(args);
+                    CraftingExit(false);
+                    return ret;
+                });
+
+                MBS_MOD_API.hookFunction("CraftingExit", 0, (args, next) => {
+                    const ret = next(args);
+                    if (CraftingMode === "Slot") {
+                        CraftingDestroy = false;
+                    }
+                    return ret;
+                });
+            }
+
+            if (MBS_MOD_API.getOriginalHash("CraftingAssetsPopulate") === "23A1297B") {
+                backportIDs.add(5205);
+
+                MBS_MOD_API.patchFunction("CraftingAssetsPopulate", {
+                    "if (a1.Group.Name === a1.DynamicGroupName) {":
+                        "if (a1.CraftGroup === a1.Name && a2.CraftGroup !== a2.Name) {",
+                    "} else if (a2.Group.Name === a2.DynamicGroupName) {":
+                        "} else if (a1.CraftGroup !== a1.Name && a2.CraftGroup === a2.Name) { return 1; } else if (a1.Group.Name === a1.DynamicGroupName && a2.Group.Name !== a2.DynamicGroupName) { return -1; } else if (a1.Group.Name !== a1.DynamicGroupName && a2.Group.Name === a2.DynamicGroupName) {",
+                });
+            }
+
+            if (MBS_MOD_API.getOriginalHash("CraftingEventListeners._ClickAsset") === "C69D32E9") {
+                backportIDs.add(5208);
+
+                MBS_MOD_API.patchFunction("CraftingEventListeners._ClickAsset", {
+                    "const needsPropertyUpdate = CraftingSelectedItem.Asset && CraftingSelectedItem.Asset !== assets[0];":
+                        "const needsPropertyUpdate = !CraftingSelectedItem.Asset || CraftingSelectedItem.Asset !== assets[0];",
+                });
+            }
             break;
         }
     }

--- a/src/common_bc.ts
+++ b/src/common_bc.ts
@@ -915,11 +915,7 @@ export function createWeightedWheelIDs(ids: string): string {
         return option === undefined ? [] : Array(option.Weight ?? 1).fill(id);
     });
     if (idBaseList.length === 0) {
-        if (GameVersion === "R107") {
-            return Array.from(ids.length > 0 ? ids : WheelFortuneDefault).sort(Math.random).join();
-        } else {
-            return "";
-        }
+        return "";
     }
 
     const idList: string[] = [];

--- a/src/fortune_wheel/fortune_wheel.ts
+++ b/src/fortune_wheel/fortune_wheel.ts
@@ -814,26 +814,12 @@ waitFor(bcLoaded).then(() => {
         return;
     }
 
-    switch (GameVersion) {
-        case "R107": {
-            MBS_MOD_API.patchFunction("WheelFortuneRun", {
-                'DrawTextWrap(TextGet((WheelFortuneVelocity == 0) ? (WheelFortuneForced ? "Forced" : "Title") : "Wait"), 1375, 200, 550, 200, "White");':
-                    ";",
-                'DrawButton(1720, 60, 90, 90, "", BackColor, "Icons/Random.png", TextGet("Random"));':
-                    ";",
-            });
-            break;
-        }
-        default: {
-            MBS_MOD_API.patchFunction("WheelFortuneRun", {
-                'DrawTextWrap(TextGet(textTag), 1375, 200, 550, 200, "White")':
-                    ";",
-                'DrawButton(1720, 60, 90, 90, "", (WheelFortuneVelocity == 0 && !isInvalidWheel) ? "White" : "Silver", "Icons/Random.png", TextGet("Random"), isInvalidWheel);':
-                    ";",
-            });
-            break;
-        }
-    }
+    MBS_MOD_API.patchFunction("WheelFortuneRun", {
+        'DrawTextWrap(TextGet(textTag), 1375, 200, 550, 200, "White")':
+            ";",
+        'DrawButton(1720, 60, 90, 90, "", (WheelFortuneVelocity == 0 && !isInvalidWheel) ? "White" : "Silver", "Icons/Random.png", TextGet("Random"), isInvalidWheel);':
+            ";",
+    });
 
     MBS_MOD_API.hookFunction("WheelFortuneLoad", 11, (args, next) => {
         wheelFortuneLoadHook();
@@ -874,7 +860,7 @@ waitFor(bcLoaded).then(() => {
 
         let text = "";
         if (WheelFortuneList.length === 0) {
-            text = GameVersion === "R107" ? "Invalid empty fortune wheel; at least one option required" : TextGet("Invalid");
+            text = TextGet("Invalid");
         } else if (WheelFortuneVelocity !== 0) {
             text = TextGet("Wait");
         } else if (!canSpin) {

--- a/src/sanity_checks.ts
+++ b/src/sanity_checks.ts
@@ -22,7 +22,7 @@ export function validateBuiltinWheelIDs(): boolean {
 }
 
 /** The minimum supported BC version. */
-export const BC_MIN_VERSION = 107 satisfies number;
+export const BC_MIN_VERSION = 108 satisfies number;
 
 /**
  * Check whether the passed BC version is supported and raise otherwise.
@@ -45,18 +45,17 @@ type HashList = readonly [Rxx: string, ...Ryy: (null | string)[]];
 const HOOK_FUNC_HASHES = (() => {
     const hashes: [keyof typeof globalThis, HashList][] = [
         ["CraftingSaveServer", ["025B434F"]],
-        ["CraftingClick", ["33579054", "083CC3CA"]],
-        ["CraftingRun", ["51577F65", "CA7B4FE0"]],
+        ["CraftingClick", ["083CC3CA"]],
+        ["CraftingRun", ["CA7B4FE0"]],
         ["SpeechTransformProcess", ["666DDA2F"]],
-        ["SpeechTransformGagGarble", ["C056FE08", "691A05BF"]],
-        ["PreferenceLoad", ["8BAC28C8", "FEEBF556"]],
-        ["WheelFortuneLoad", ["204D57D4", "EA252C35"]],
-        ["WheelFortuneClick", ["21CCD6B4", "D368BBF2"]],
-        ["WheelFortuneRun", ["150059B6", "D4DF7BB8"]],
-        ["WheelFortuneMouseUp", ["1465BDFA", "887E5D09"]],
-        ["WheelFortuneMouseDown", ["306C80B6", "78354D35"]],
+        ["SpeechTransformGagGarble", ["691A05BF"]],
+        ["WheelFortuneLoad", ["EA252C35"]],
+        ["WheelFortuneClick", ["D368BBF2"]],
+        ["WheelFortuneRun", ["D4DF7BB8"]],
+        ["WheelFortuneMouseUp", ["887E5D09"]],
+        ["WheelFortuneMouseDown", ["78354D35"]],
         ["WheelFortuneCustomizeLoad", ["97F0A81E"]],
-        ["WheelFortuneDrawWheel", ["A8BF62A5", "B21DAEA9"]],
+        ["WheelFortuneDrawWheel", ["B21DAEA9"]],
     ];
     return Object.freeze(Object.fromEntries(hashes.map(item => {
         const [key, value] = item;

--- a/src/settings/settings_screen.tsx
+++ b/src/settings/settings_screen.tsx
@@ -29,7 +29,15 @@ export class PreferenceScreenProxy extends ScreenProxy {
                 Run: PreferenceRun,
                 Click: PreferenceClick,
                 Exit: PreferenceExit,
-                Load: () => CommonSetScreen("Character", "Preference"),
+                Load: () => {
+                    CommonSetScreen("Character", "Preference");
+                    PreferencePageCurrent = 1;
+                    const screen = PreferenceSubscreens.find(e => e.name === "Extensions");
+                    if (screen) {
+                        screen.load?.();
+                        PreferenceSubscreen = screen;
+                    }
+                },
             },
         );
     }

--- a/src/settings/settings_screen.tsx
+++ b/src/settings/settings_screen.tsx
@@ -1,4 +1,4 @@
-import { MBS_MOD_API, waitFor, logger } from "../common";
+import { waitFor, logger } from "../common";
 import { bcLoaded } from "../common_bc";
 import { MBSScreen, ScreenProxy, ScreenParams } from "../screen_abc";
 import { FWSelectScreen, loadFortuneWheelObjects } from "../fortune_wheel";
@@ -16,17 +16,6 @@ import {
 import { garblingJSON } from "../garbling";
 
 import styles from "./settings_screen.scss";
-
-function preferenceLoadHook() {
-    if (TextScreenCache != null) {
-        TextScreenCache.cache[`Homepage${MBSPreferenceScreen.screen}`] = "MBS Settings";
-    }
-
-    const img = new Image();
-    img.addEventListener("error", () => DrawGetImageOnError(img, false));
-    img.src = "Icons/Maid.png";
-    DrawCacheImage.set(`Icons/${MBSPreferenceScreen.screen}.png`, img);
-}
 
 export class PreferenceScreenProxy extends ScreenProxy {
     static readonly screen = "Preference";
@@ -381,50 +370,16 @@ let preferenceState: PreferenceScreenProxy;
 waitFor(bcLoaded).then(() => {
     preferenceState = new PreferenceScreenProxy();
 
-    switch (GameVersion) {
-        case "R107": {
-            MBS_MOD_API.hookFunction("PreferenceLoad", 0, (args, next) => {
-                next(args);
-                preferenceLoadHook();
-            });
-
-            ServerPlayerChatRoom.register({
-                screen: MBSPreferenceScreen.screen,
-                callback: () => InformationSheetPreviousScreen === "ChatRoom",
-            });
-
-            MBS_MOD_API.hookFunction("PreferenceClick", 0, (args, next) => {
-                const previousScreen = PreferenceSubscreen;
-                next(args);
-                // @ts-expect-error
-                if (!previousScreen && PreferenceSubscreen as string === MBSPreferenceScreen.screen) {
-                    PreferenceExit();
-                    preferenceState.loadChild(MBSPreferenceScreen);
-                }
-            });
-
-            (PreferenceSubscreenList as string[]).push(MBSPreferenceScreen.screen);
-
-            if (CurrentScreen === "Preference") {
-                preferenceLoadHook();
-            }
-            break;
-        }
-
-        default: { // R108
-            PreferenceRegisterExtensionSetting({
-                Identifier: "MBS",
-                load() {
-                    PreferenceExit();
-                    preferenceState.loadChild(MBSPreferenceScreen);
-                },
-                run() {},
-                click() {},
-                exit() {},
-                ButtonText: "MBS Settings",
-                Image: "Icons/Maid.png",
-            });
-            break;
-        }
-    }
+    PreferenceRegisterExtensionSetting({
+        Identifier: "MBS",
+        load() {
+            PreferenceExit();
+            preferenceState.loadChild(MBSPreferenceScreen);
+        },
+        run() {},
+        click() {},
+        exit() {},
+        ButtonText: "MBS Settings",
+        Image: "Icons/Maid.png",
+    });
 });


### PR DESCRIPTION
* Drop R107 support
* Ensure that exiting the MBS preference screen returns one to the preference extension subscreen
* Backport three R109 changes:
    - [BondageProjects/Bondage-College#5205](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5205): Take `Asset.CraftGroup` into account when sorting crafted items
    - [BondageProjects/Bondage-College#5207](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5207): Fix two crafting screen bugs
    - [BondageProjects/Bondage-College#5208](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5208): Fix the appropriate default color failing to be selected upon creating a new crafted item