### PR TITLE
REL: Version bump: 1.7.32 > 1.7.33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # MBS Changelog
 
+## v1.7.33
+* Backport four R111 bug fixes:
+    - [BondageProjects/Bondage-College#5264](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5264): Ensure that voice-triggered auto-punishments more thoroughly check for OOC blocks
+    - [BondageProjects/Bondage-College#5272](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5272): Silence deprecation warning about mobile-web-app-capable
+    - [BondageProjects/Bondage-College#5274](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5274): Fix the shop not properly unhiding DOM elements after exiting certain subscreens
+    - [BondageProjects/Bondage-College#5290](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5290): Fix blur effects being enabled by default when rendering backgrounds
+
 ## v1.7.32
 * Drop R109 support
 * Add a setting for enabling or disabling MBS changelog notifications

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version     1.7.32.dev0
+// @version     1.7.33.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version     1.7.32
+// @version     1.7.33
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.7.32",
+    "version": "1.7.33",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/backport.scss
+++ b/src/backport.scss
@@ -6,6 +6,10 @@
     white-space: normal;
 }
 
+.chat-room-changelog + .chat-room-changelog {
+    border-top: min(0.4dvh, 0.2dvw) solid black;
+}
+
 #TextAreaChatLog[data-colortheme="dark"] > .chat-room-changelog,
 #TextAreaChatLog[data-colortheme="dark2"] > .chat-room-changelog {
     background-color: #481D64;

--- a/src/backport.tsx
+++ b/src/backport.tsx
@@ -19,6 +19,56 @@ export const backportIDs: Set<number> = new Set();
 waitFor(bcLoaded).then(() => {
     switch (GameVersion) {
         case "R110": {
+            if (MBS_MOD_API.getOriginalHash("PropertyAutoPunishParseMessage") === "B0B55044") {
+                backportIDs.add(5264);
+                MBS_MOD_API.hookFunction("PropertyAutoPunishParseMessage", 0, ([sensitivity, msg, ...args], next) => {
+                    const oocRanges = SpeechGetOOCRanges(msg).reverse();
+                    const arrayMsg = Array.from(msg);
+                    oocRanges.forEach(({ start, length }) => arrayMsg.splice(start, length));
+                    msg = arrayMsg.join("");
+                    return (next([sensitivity, msg, ...args]));
+                });
+            }
+
+            if (!document.head.querySelector("meta[name='mobile-web-app-capable']")) {
+                backportIDs.add(5272);
+                const titleElem = document.head.querySelector("title");
+                if (titleElem) {
+                    document.head.insertBefore(<meta name="mobile-web-app-capable" content="yes" />, titleElem);
+                } else {
+                    document.head.append(<meta name="mobile-web-app-capable" content="yes" />);
+                }
+            }
+
+            if (MBS_MOD_API.getOriginalHash("Shop2.Elements.InputSearch.Load") === "0F083C95") {
+                backportIDs.add(5274);
+
+                MBS_MOD_API.hookFunction("Shop2.Elements.InputSearch.Load", 0, (args, next) => {
+                    const ret = next(args);
+                    const elem = document.getElementById("Shop2InputSearch");
+                    if (elem) {
+                        elem.style.display = "";
+                    }
+                    return ret;
+                });
+
+                Layering._ExitCallbacks.pop();
+                Layering.RegisterExitCallbacks({
+                    screen: "Shop2",
+                    callback: () => {
+                        Shop2Vars.Mode = "Preview";
+                        Shop2Load();
+                    },
+                });
+            }
+
+            if (MBS_MOD_API.getOriginalHash("DrawRoomBackground") === "5B829E54") {
+                backportIDs.add(5290);
+                MBS_MOD_API.patchFunction("DrawRoomBackground", {
+                    "blur ??= 1.0;":
+                        "blur ??= 0.0;",
+                });
+            }
             break;
         }
     }


### PR DESCRIPTION
* Backport four R111 bug fixes:
    - [BondageProjects/Bondage-College#5264](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5264): Ensure that voice-triggered auto-punishments more thoroughly check for OOC blocks
    - [BondageProjects/Bondage-College#5272](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5272): Silence deprecation warning about mobile-web-app-capable
    - [BondageProjects/Bondage-College#5274](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5274): Fix the shop not properly unhiding DOM elements after exiting certain subscreens
    - [BondageProjects/Bondage-College#5290](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5290): Fix blur effects being enabled by default when rendering backgrounds