### PR TITLE
REL: Version bump: 1.7.40 > 1.7.41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MBS Changelog
 
+## v1.7.41
+* Backport three BC R114 fixes:
+    - [BondageProjects/Bondage-College#5433](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5433): Make the `dialog` status scroll + expand upon overflow rather than clamping
+    - [BondageProjects/Bondage-College#5429](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5429): Fix password padlock drawing hint text with last assigned color
+    - [BondageProjects/Bondage-College#5432](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5432): Connect normalize
+
 ## v1.7.40
 * Drop R112 support
 * Restructure the way MBS handles the detection of BC and BC logins

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.7.40.dev0
+// @version      1.7.41.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.7.40
+// @version      1.7.41
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.7.40",
+    "version": "1.7.41",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/backport.scss
+++ b/src/backport.scss
@@ -1,1 +1,38 @@
 /* stylelint-disable no-empty-source */
+
+.dialog-status {
+	display: block;
+	line-clamp: unset;
+	-webkit-line-clamp: unset;
+	-webkit-box-orient: unset;
+	max-height: 4.8em; /* 4 lines */
+	min-height: 1.2em; /* 1 line */
+	overflow: hidden auto;
+	scroll-padding: 3px;
+	scrollbar-color: rgb(149 149 149) rgb(0 0 0 / 70%);
+	scrollbar-gutter: stable;
+}
+
+@media (hover: hover) {
+	.dialog-status {
+		scrollbar-color: rgb(149 149 149 / 90%) rgb(0 0 0 / 40%);
+		transition: scrollbar-color 0.3s ease;
+	}
+
+	.dialog-status:hover {
+		scrollbar-color: rgb(149 149 149) rgb(0 0 0 / 70%);
+	}
+}
+
+#dialog-dialog {
+	grid-template:
+		". dialog-status dialog-menubar" min-content
+		"dialog-paginate dialog-grid dialog-grid" auto / var(--menu-button-size) auto calc(var(--menu-button-size) + 3px + var(--scrollbar-gutter));
+}
+
+#dialog-dialog-status {
+	line-clamp: unset;
+	-webkit-line-clamp: unset;
+	max-height: 7.2em; /* 6 lines */
+	min-height: 3.6em; /* 3 lines */
+}

--- a/src/backport.tsx
+++ b/src/backport.tsx
@@ -16,83 +16,56 @@ const BC_NEXT = BC_MIN_VERSION + 1;
 /** A set with the pull request IDs of all applied bug fix backports */
 export const backportIDs: Set<number> = new Set();
 
-type Character2 = Character & { _Stage: string, _CurrentDialog: string };
-
-function updateGetters(char: Character) {
-    if ("_Stage" in char && "_CurrentDialog" in char) {
-        return;
-    }
-
-    const char2 = char as Character2;
-    char2._Stage = char2.Stage;
-    char2._CurrentDialog = char2.CurrentDialog;
-    Object.defineProperty(char2, "Stage", {
-        get(this: Character2) {
-            return this._Stage;
-        },
-        set(this: Character2, value: string) {
-            if (this._Stage === value) {
-                return;
-            }
-            this._Stage = value;
-            if (DialogMenuMode === "dialog") {
-                DialogMenuMapping.dialog.Reload();
-            }
-        },
-    });
-    Object.defineProperty(char2, "CurrentDialog", {
-        get(this: Character2) {
-            return this._CurrentDialog;
-        },
-        set(this: Character2, value: string) {
-            if (this._CurrentDialog === value) {
-                return;
-            }
-            this._CurrentDialog = value;
-            if (DialogMenuMode === "dialog") {
-                DialogSetStatus(value);
-            }
-        },
-    });
-}
-
 waitForBC("backport", {
     async afterLoad() {
         switch (GameVersion) {
-            case "R113":
-                if (MBS_MOD_API.getOriginalHash("CharacterCreate") === "F078CBBE") {
-                    backportIDs.add(5410);
-                    MBS_MOD_API.hookFunction("CharacterCreate", 11, (args, next) => {
-                        const char = next(args);
-                        updateGetters(char);
-                        return char;
+            case "R113": {
+                if (MBS_MOD_API.getOriginalHash("CharacterCreate") === "E571DB6D") {
+                    backportIDs.add(5433);
+                    MBS_MOD_API.hookFunction("CharacterCreate", 0, (args, next) => {
+                        const ret = next(args);
+                        ret.ClickedOption = null;
+                        return ret;
                     });
-                    MBS_MOD_API.patchFunction("DialogLoad", {
-                        "C.CurrentDialog = newDialog;":
-                            "C._CurrentDialog = newDialog;",
+                    MBS_MOD_API.hookFunction("DialogLeave", 0, (args, next) => {
+                        if (CurrentCharacter) {
+                            CurrentCharacter.ClickedOption = null;
+                        }
+                        return next(args);
                     });
-                    Character.forEach(char => updateGetters(char));
+                    MBS_MOD_API.hookFunction("DialogMenuMapping.dialog._ClickButton", 0, ([button, char, clickedDialog, ...args], next) => {
+                        char.ClickedOption = clickedDialog.Option;
+                        return next([button, char, clickedDialog, ...args]);
+                    });
+                    MBS_MOD_API.patchFunction("DialogRemove", {
+                        "const dialogIndex = C.Dialog.findIndex(dialog => dialog.Stage === C.Stage && dialog.Option != null && DialogPrerequisite(dialog));":
+                            "const dialogIndex = C.Dialog.findIndex(dialog => dialog.Stage === C.Stage && dialog.Option === C.ClickedOption && dialog.Option != null && DialogPrerequisite(dialog));",
+                    });
                 }
 
-                if (
-                    MBS_MOD_API.getOriginalHash("ElementButton.CreateForAsset") === "591D7DCF"
-                    && MBS_MOD_API.getOriginalHash("ElementButton.CreateForActivity") === "3A1D0F81"
-                ) {
-                    backportIDs.add(5412);
-                    MBS_MOD_API.patchFunction("ElementButton.CreateForAsset", {
-                        "options.icons ??= [":
-                            "options.icons = [",
+                if (MBS_MOD_API.getOriginalHash("InventoryItemMiscPasswordPadlockDrawControls") === "AC76D6DE") {
+                    backportIDs.add(5429);
+                    MBS_MOD_API.patchFunction("InventoryItemMiscPasswordPadlockDrawControls", {
+                        ", 1000, 640, 1000, 120, null, null, 2);":
+                            ', 1000, 640, 1000, 120, "white", null, 2);',
                     });
-                    MBS_MOD_API.patchFunction("ElementButton.CreateForActivity", {
-                        "options.icons ??= [":
-                            "options.icons = [",
-                    });
+                }
+
+                let normalizeLink = document.head.querySelector("link[href='CSS/normalize.css']") as null | HTMLLinkElement;
+                const nextSibling = document.head.querySelector("link[href='CSS/Styles.css']");
+                if (!normalizeLink && nextSibling) {
+                    backportIDs.add(5432);
+                    normalizeLink = document.createElement("link");
+                    normalizeLink.href = "CSS/normalize.css";
+                    normalizeLink.rel = "stylesheet";
+                    document.head.insertBefore(normalizeLink, nextSibling);
                 }
 
                 if (!document.getElementById("mbs-backport-style")) {
                     document.body.append(<style id="mbs-backport-style">{styles.toString()}</style>);
                 }
                 break;
+            }
         }
 
         if (backportIDs.size) {

--- a/src/stub_files/patches.d.ts
+++ b/src/stub_files/patches.d.ts
@@ -10,6 +10,11 @@ interface PlayerCharacter {
     MBSSettings: MBSSettings,
 }
 
+// R113 patch
+interface Character {
+    ClickedOption: null | string;
+}
+
 interface PlayerOnlineSettings {
     /** @deprecated moved to {@link ExtensionSettings.MBS} as of v1.1.0 */
     MBS?: string,


### PR DESCRIPTION
* Backport three BC R114 fixes:
    - [BondageProjects/Bondage-College#5433](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5433): Make the `dialog` status scroll + expand upon overflow rather than clamping
    - [BondageProjects/Bondage-College#5429](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5429): Fix password padlock drawing hint text with last assigned color
    - [BondageProjects/Bondage-College#5432](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5432): Connect normalize