### PR TITLE
REL: Version bump: 1.7.41 > 1.7.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # MBS Changelog
 
+## v1.7.42
+* Expand the number of supported wheel of fortune item properties
+    - Includes, among others, expanded item opacity support
+* Add BC R114Beta1 support
+* Backport two BC R114 fixes:
+    - [BondageProjects/Bondage-College#5438](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5438): Stop the tongue piercing gag from blocking its own group
+    - [BondageProjects/Bondage-College#5440](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5440): Fix the wheel of fortune potentially initializing to the wrong character
+    - [BondageProjects/Bondage-College#5447](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5447): Fix `CommonDynamicFunctionParams()` incorrectly parsing parameters of length 0
+
 ## v1.7.41
 * Backport three BC R114 fixes:
     - [BondageProjects/Bondage-College#5433](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5433): Make the `dialog` status scroll + expand upon overflow rather than clamping

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.7.41.dev0
+// @version      1.7.42.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.7.41
+// @version      1.7.42
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.7.41",
+    "version": "1.7.42",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     },
     "dependencies": {
         "@types/lodash-es": "^4.17.12",
-        "bc-data": "^113.0.0",
-        "bc-stubs": "^113.0.0",
+        "bc-data": "^114.0.0-Beta.1",
+        "bc-stubs": "^114.0.0-Beta.1",
         "bondage-club-mod-sdk": "^1.2.0",
         "lodash-es": "^4.17.21",
         "typed-scss-modules": "^8.1.1"

--- a/src/backport.tsx
+++ b/src/backport.tsx
@@ -51,6 +51,32 @@ waitForBC("backport", {
                     });
                 }
 
+                if (MBS_MOD_API.getOriginalHash("InventoryItemDevicesWheelFortuneLoadHook") === "CDE51F46") {
+                    backportIDs.add(5440);
+                    MBS_MOD_API.patchFunction("InventoryItemDevicesWheelFortuneLoadHook", {
+                        "WheelFortuneCharacter = CurrentCharacter;":
+                            "WheelFortuneCharacter = CharacterGetCurrent();",
+                    });
+                }
+
+                if (MBS_MOD_API.getOriginalHash("CommonDynamicFunctionParams") === "F9CFFE56") {
+                    backportIDs.add(5447);
+                    MBS_MOD_API.patchFunction("CommonDynamicFunctionParams", {
+                        'var Params = FunctionName.substring(openParenthesisIndex + 1, closedParenthesisIndex).split(",");':
+                            'var ParamsString = FunctionName.substring(openParenthesisIndex + 1, closedParenthesisIndex); var Params = ParamsString.length === 0 ? [] : ParamsString.split(",");',
+                    });
+                }
+
+                const gag2 = AssetGet("Female3DCG", "ItemMouth2", "TonguePiercingGag");
+                const gag3 = AssetGet("Female3DCG", "ItemMouth3", "TonguePiercingGag");
+                const idx2 = gag2?.Block?.findIndex(i => i === "ItemMouth2") ?? -1;
+                const idx3 = gag3?.Block?.findIndex(i => i === "ItemMouth3") ?? -1;
+                if (gag2 && gag3 && idx2 !== -1 && idx3 !== -1) {
+                    backportIDs.add(5438);
+                    (gag2.Block as AssetGroupItemName[])[idx2] = "ItemMouth";
+                    (gag3.Block as AssetGroupItemName[])[idx3] = "ItemMouth";
+                }
+
                 let normalizeLink = document.head.querySelector("link[href='CSS/normalize.css']") as null | HTMLLinkElement;
                 const nextSibling = document.head.querySelector("link[href='CSS/Styles.css']");
                 if (!normalizeLink && nextSibling) {

--- a/src/fortune_wheel/item_bundle.ts
+++ b/src/fortune_wheel/item_bundle.ts
@@ -66,7 +66,26 @@ const PROP_MAPPING = <Readonly<PropMappingType>>Object.freeze({
             return false;
         }
     },
-    Opacity: (p, a) => typeof p === "number" && p <= a.MaxOpacity && p >= a.MinOpacity,
+    Opacity: (p, a) => {
+        if (typeof p === "number") {
+            return p <= a.MaxOpacity && p >= a.MinOpacity;
+        } else if (isArray(p)) {
+            const layers = ItemColorGetColorableLayers({ Asset: a });
+            return p.every((opacity, i) => {
+                const layer = layers[i];
+                if (!layer) {
+                    return false;
+                }
+                return (
+                    typeof opacity === "number"
+                    && opacity <= layer.MaxOpacity
+                    && opacity >= layer.MinOpacity
+                );
+            });
+        } else {
+            return false;
+        }
+    },
     Text: (p, a) => validateText("Text", p, a),
     Text2: (p, a) => validateText("Text2", p, a),
     Text3: (p, a) => validateText("Text3", p, a),
@@ -86,6 +105,7 @@ const PROP_MAPPING = <Readonly<PropMappingType>>Object.freeze({
     },
     TargetAngle: (p, _) => typeof p === "number" && p >= 0 && p <= 360,
     OverrideHeight: validateOverrideHeight,
+    PunishActivity: (p, _) => typeof p === "boolean",
     PunishStruggle: (p, _) => typeof p === "boolean",
     PunishStruggleOther: (p, _) => typeof p === "boolean",
     PunishRequiredSpeechWord: (p, _) => typeof p === "string" && p.length <= 70,
@@ -97,6 +117,11 @@ const PROP_MAPPING = <Readonly<PropMappingType>>Object.freeze({
     PublicModePermission: (p, _) => isInteger(p) && p >= 0 && p < FuturisticTrainingBeltPermissions.length,
     ShockLevel: (p, _) => isInteger(p) && p >= 0 && p <= 2,
     PortalLinkCode: (p, _) => typeof p === "string" && PortalLinkCodeRegex.test(p),
+    OpenPermission: (p, _) => typeof p === "boolean",
+    OpenPermissionChastity: (p, _) => typeof p === "boolean",
+    OpenPermissionArm: (p, _) => typeof p === "boolean",
+    OpenPermissionLeg: (p, _) => typeof p === "boolean",
+    BlockRemotes: (p, _) => typeof p === "boolean",
 });
 
 /**

--- a/src/fortune_wheel/preset_screen.tsx
+++ b/src/fortune_wheel/preset_screen.tsx
@@ -169,7 +169,7 @@ const ID = Object.freeze({
 
 export class WheelPresetScreen extends MBSScreen {
     static readonly background = "Sheet";
-    static readonly screen = `MBS_${WheelPresetScreen.name}`;
+    static readonly screen = "MBS_WheelPresetScreen";
     static readonly ids = ID;
     static readonly screenParamsDefault = {
         [root]: Object.freeze({

--- a/src/screen_abc.ts
+++ b/src/screen_abc.ts
@@ -19,7 +19,7 @@ export abstract class MBSScreen {
     /** The name of the screen's background. */
     static readonly background: string = "Sheet";
     /** The name of the screen. */
-    static readonly screen: string = "";
+    static readonly screen: RoomName;
     /** The name of the screen. */
     get screen() {
         return (this.constructor as typeof MBSScreen).screen;
@@ -100,7 +100,6 @@ export abstract class MBSScreen {
 
     /** Called when screen is loaded */
     load(): void {
-        const prevScreen = CurrentScreen;
         CurrentScreenFunctions?.Unload?.();
         if (ControllerIsActive()) {
             ControllerClearAreas();
@@ -112,9 +111,6 @@ export abstract class MBSScreen {
         CommonGetFont.clearCache();
         CommonGetFontName.clearCache();
         CurrentScreenFunctions?.Resize?.(true);
-        if (prevScreen == "ChatSearch" || prevScreen == "ChatCreate") {
-            ChatRoomStimulationMessage("Walk");
-        }
     }
 
     loadChild<T extends readonly any[], RT extends MBSScreen>(

--- a/src/stub_files/patches.d.ts
+++ b/src/stub_files/patches.d.ts
@@ -41,3 +41,13 @@ interface WheelFortuneOptionType {
     /** The weight of a particular option within the wheel of fortune */
     readonly Weight?: number,
 }
+
+interface ModuleScreens {
+    MBS: (
+        "MBS_PreferenceScreen"
+        | "MBS_FWSelectScreen"
+        | "MBS_WheelPresetScreen"
+        | "MBS_FWItemSetScreen"
+        | "MBS_FWCommandScreen"
+    );
+}


### PR DESCRIPTION
* Expand the number of supported wheel of fortune item properties
    - Includes, among others, expanded item opacity support
* Add BC R114Beta1 support
* Backport two BC R114 fixes:
    - [BondageProjects/Bondage-College#5438](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5438): Stop the tongue piercing gag from blocking its own group
    - [BondageProjects/Bondage-College#5440](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5440): Fix the wheel of fortune potentially initializing to the wrong character
    - [BondageProjects/Bondage-College#5447](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5447): Fix `CommonDynamicFunctionParams()` incorrectly parsing parameters of length 0