### PR TITLE
REL: Version bump: 1.7.45 > 1.7.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MBS Changelog
 
+## v1.7.46
+* Remove all reference to the old extended crafted description feature as it's been available in unmodded Bondage Club ever since R109 (see the crafting screen)
+* Fix a [BondageProjects/Bondage-College#5347](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5347) backport making player names in the chat log unselectable
+
 ## v1.7.45
 * Fix a crash due to an invalid CSS selector in the MBS settings screen
 * Fix a [BondageProjects/Bondage-College#5347](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5347) backport crash due to usage of an invalid event listener

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.7.45.dev0
+// @version      1.7.46.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.7.45
+// @version      1.7.46
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.7.45",
+    "version": "1.7.46",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/backport.scss
+++ b/src/backport.scss
@@ -4,6 +4,11 @@
 	user-select: none;
 }
 
+/* stylelint-disable selector-class-pattern */
+.ChatMessageName {
+	user-select: text;
+}
+
 @media (hover: none) {
 	.button[data-show-tooltip] > .button-tooltip {
 		visibility: visible;

--- a/src/lpgl/common.ts
+++ b/src/lpgl/common.ts
@@ -397,8 +397,11 @@ async function contentLoadedListener() {
 export function waitForBC(
     name: BCListenerNames,
     listeners: {
+        /** To be executed after the documents `DOMContentLoaded` event */
         afterLoad?: () => Promise<void>,
+        /** To be executed after logging in and running `afterLoad` */
         afterLogin?: () => Promise<void>,
+        /** To be executed after the documents `DOMContentLoaded` event */
         afterMBS?: () => Promise<void>,
     },
 ) {

--- a/src/sanity_checks.ts
+++ b/src/sanity_checks.ts
@@ -32,7 +32,7 @@ const HOOK_FUNC_HASHES = (() => {
     const hashes: [keyof typeof globalThis, HashList][] = [
         ["CraftingSaveServer", ["025B434F"]],
         ["CraftingClick", ["5E7225EA"]],
-        ["CraftingRun", ["4CD7AB08"]],
+        ["CraftingRun", ["4CD7AB08", "BF33E4B6"]],
         ["SpeechTransformProcess", ["666DDA2F"]],
         ["SpeechTransformGagGarble", ["691A05BF"]],
         ["WheelFortuneLoad", ["EA252C35"]],

--- a/src/settings/settings_screen.tsx
+++ b/src/settings/settings_screen.tsx
@@ -61,7 +61,6 @@ const ID = Object.freeze({
     wheelHeader: `${root}-wheel-header`,
     miscHeader: `${root}-misc-header`,
     garbleHeader: `${root}-garble-header`,
-    craftingHeader: `${root}-garble-header`,
 
     wheelLabel: `${root}-wheel-label`,
     rollRestrainedLabel: `${root}-roll-restrained-label`,
@@ -119,7 +118,7 @@ export class MBSPreferenceScreen extends MBSScreen {
                             { image: "Icons/Exit.png", tooltip: "Exit" },
                         ),
                     ],
-                    { direction: "ltr" },
+                    { direction: "rtl" },
                 )}
 
                 <main id={ID.settingsGrid} role="form" aria-label="Configure MBS">
@@ -176,17 +175,6 @@ export class MBSPreferenceScreen extends MBSScreen {
                             <input type="checkbox" class="checkbox" name="ShowChangelog" onClick={this.#boolSwitch.bind(this)} aria-labelledby={ID.changelogLabel}/>
                             <span id={ID.changelogLabel}>Show the MBS changelog in chat whenever a new MBS version is released</span>
                         </div>
-                    </section>
-
-                    <section aria-labelledby={ID.craftingHeader}>
-                        <h2 id={ID.craftingHeader}>Crafting settings</h2>
-                        <p class="mbs-preference-settings-pair">
-                            <input type="checkbox" class="checkbox" disabled={true} aria-labelledby={ID.extendedCraftLabel}/>
-                            <span style={{ color: "gray" }} id={ID.extendedCraftLabel}>
-                                Allow crafted item descriptions to use up to 398 "simple" characters (<i>e.g.</i> no smilies or other non-ASCII characters).<br />
-                                Note: Available in unmodded Bondage Club as of R109; see the crafting screen
-                            </span>
-                        </p>
                     </section>
                 </main>
 


### PR DESCRIPTION
* Remove all reference to the old extended crafted description feature as it's been available in unmodded Bondage Club ever since R109 (see the crafting screen)
* Fix a [BondageProjects/Bondage-College#5347](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5347) backport making player names in the chat log unselectable