### PR TITLE
REL: Version bump: 1.8.1 > 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # MBS Changelog
 
+## v1.8.2
+* Wheel event API:
+    - Fix the example mod names as used in the readme
+    - Clean up the styling of various kwarg-related DOM elements
+    - Fix default values of `number` kwarg inputs failing to be assigned
+    - Fix a failure to look up the original kwarg config
+    - Fix `number` kwargs improperly checking for finite values
+    - Make the wheel event registration logic more strict w.r.t. checking for MBS-esque names
+
 ## v1.8.1
 * Fix a crash when creating a new wheel outfit
 * Fix wheel of fortune hook kwargs not being initially disabled when creating new item sets

--- a/api/README.md
+++ b/api/README.md
@@ -27,11 +27,18 @@ Since MBS v1.8.0 it is possible for addons to register event listeners for the w
 ## Wheel event listener examples
 
 ```ts
-const MySdkInfo: import("bondage-club-mod-sdk").ModSDKModInfo;
+import bcModSdk from "bondage-club-mod-sdk";
+
+const modName = "TST";
+bcModSdk.registerMod({
+    name: modName,
+    fullName: "My test mod",
+    version: "1.0.0",
+});
 
 mbs.wheelEvents.addEventListener(
     "beforeItemEquip",
-    MySdkInfo,
+    modName,
     {
         listener(ev, kwargs) {
             const difficulty = kwargs.difficulty;
@@ -55,11 +62,11 @@ mbs.wheelEvents.addEventListener(
 
 mbs.wheelEvents.addEventListener(
     "beforeItemEquip",
-    MySdkInfo,
+    modName,
     {
         listener(ev, kwargs) {
             const color = kwargs.color;
-            if (color?.type === "select" && color.value !== und efined) {
+            if (color?.type === "select" && color.value !== undefined) {
                 ev.color.fill(color.value);
             }
         },
@@ -81,7 +88,7 @@ mbs.wheelEvents.addEventListener(
 
 mbs.wheelEvents.addEventListener(
     "validateItemEquip",
-    MySdkInfo,
+    modName,
     {
         listener(ev, kwargs) {
             if (ev.newAsset.Name.includes("Cheese")) {
@@ -97,7 +104,7 @@ mbs.wheelEvents.addEventListener(
 
 mbs.wheelEvents.addEventListener(
     "afterOutfitEquip",
-    MySdkInfo,
+    modName,
     {
         listener(ev, kwargs) {
             ChatRoomSendLocal("Hello world!");

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.8.1.dev0
+// @version      1.8.2.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.8.1
+// @version      1.8.2
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/api/wheel_events.ts
+++ b/src/api/wheel_events.ts
@@ -28,7 +28,7 @@ export const addEventListener: typeof mbs.wheelEvents.addEventListener = functio
     const addonData = bcModSdk.getModsInfo().find(i => i.name === addonName);
     if (!addonData) {
         throw new Error(`Addon "${addonName}" is not registered in bcModSdk`);
-    } else if (addonName === "mbs") {
+    } else if (addonName.normalize().toLowerCase() === "mbs") {
         throw new Error("Cannot register event listener to addon \"MBS\"");
     }
 

--- a/src/fortune_wheel/events/kwarg_config_to_elem.tsx
+++ b/src/fortune_wheel/events/kwarg_config_to_elem.tsx
@@ -147,7 +147,7 @@ function _parseNumber(
     options: WheelEvents.KwargsConfig.Number,
     settings: import("../../common_bc").FWSelectedItemSet,
 ): HTMLInputElement {
-    const children: (string | Element)[] = [options.default.toString()];
+    const children: (string | Element)[] = [];
     let list: undefined | string = undefined;
     if (options.suggestions) {
         children.push(<datalist id={`${idPrefix}-${name}-datalist`}>{options.suggestions.map(i => <option>{i}</option>)}</datalist>);
@@ -165,9 +165,10 @@ function _parseNumber(
         tag: "input",
         attributes: {
             type: "number",
-            min: options.min.toString(),
-            max: options.max.toString(),
-            step: options.step == null ? undefined : options.step.toString(),
+            min: options.min,
+            max: options.max,
+            value: options.default,
+            step: options.step == null ? undefined : options.step,
             inputmode: options.inputmode ?? inputmode,
             list,
             size: 0,

--- a/src/fortune_wheel/events/kwarg_config_to_elem.tsx
+++ b/src/fortune_wheel/events/kwarg_config_to_elem.tsx
@@ -212,7 +212,7 @@ function _parseCheckbox(
             name,
             disabled: true,
         },
-        classList: ["mbs-fwitemset-event-kwarg-config"],
+        classList: ["checkbox", "mbs-fwitemset-event-kwarg-config"],
         eventListeners: {
             change: _getChangeInput(settings),
         },

--- a/src/fortune_wheel/events/kwarg_validation.ts
+++ b/src/fortune_wheel/events/kwarg_validation.ts
@@ -100,12 +100,12 @@ function _validateNumber(
 
     switch (kwargConfig?.type) {
         case undefined:
-            if (typeof kwargParsed.value !== "number" || Number.isFinite(kwargParsed.value)) {
+            if (typeof kwargParsed.value !== "number" || !Number.isFinite(kwargParsed.value)) {
                 return null;
             }
             return kwargParsed;
         case "number":
-            if (typeof kwargParsed.value !== "number" || Number.isFinite(kwargParsed.value)) {
+            if (typeof kwargParsed.value !== "number" || !Number.isFinite(kwargParsed.value)) {
                 kwargParsed.value = kwargConfig.default;
             }
             if (!inRange(kwargParsed.value, kwargConfig.min, kwargConfig.max)) {

--- a/src/fortune_wheel/events/kwarg_validation.ts
+++ b/src/fortune_wheel/events/kwarg_validation.ts
@@ -178,7 +178,7 @@ export function validateHooks(
             && (typeof hook.kwargs === "object" && hook.kwargs !== null)
         ) {
             const allKwargs: Mutable<FWHook["kwargs"]> = {};
-            const allKwargsConfig = register[hook.hookType]?.find(i => i.hookName === hook.hookName && i.hookType === hook.hookName)?.kwargs ?? {};
+            const allKwargsConfig = register[hook.hookType]?.find(i => i.hookName === hook.hookName && i.hookType === hook.hookType)?.kwargs ?? {};
             for (const [kwargName, _kwarg] of Object.entries(hook.kwargs)) {
                 const kwarg: WheelEvents.Kwargs.All | WheelEvents.Kwargs.JsonAll = _kwarg;
                 const kwargConfig = allKwargsConfig[kwargName];

--- a/src/fortune_wheel/fortune_wheel_item_set.scss
+++ b/src/fortune_wheel/fortune_wheel_item_set.scss
@@ -224,20 +224,37 @@
 				box-shadow: unset;
 			}
 
-			&[type="text"] {
-				height: 1em;
-				width: 100%;
+			&:disabled {
+				background-color: color-mix(in srgb, var(--mbs-button-color) 60%, black 40%);
 			}
 
+			&[type="text"],
 			&[type="number"] {
-				height: 1em;
-				width: 50%;
+				border-color: black;
+				direction: ltr;
+				height: 1.15em;
+				width: 100%;
 			}
 		}
 	}
 
 	.mbs-fwitemset-event-kwargs {
+		align-items: center;
+		column-gap: var(--gap);
+		direction: rtl;
+		display: grid;
+		grid-auto-flow: column;
+		grid-template-columns: 3fr 1fr;
+		text-align: left;
+		width: 100%;
+
+		&:has(select) {
+			display: block;
+			text-align: center;
+		}
+
 		& > * {
+			direction: ltr;
 			margin-block: var(--gap);
 		}
 


### PR DESCRIPTION
* Wheel of fortune events API:
    - Fix the example mod names as used in the readme
    - Clean up the styling of various kwarg-related DOM elements
    - Fix default values of `number` kwarg inputs failing to be assigned
    - Fix a failure to look up the original kwarg config
    - Fix `number` kwargs improperly checking for finite values
    - Make the wheel event registration logic more strict w.r.t. checking for MBS-esque names