### PR TITLE
REL: Version bump: 1.8.3 > 1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # MBS Changelog
 
+## v1.8.4
+* Add support for BC R116Beta1
+* Fix the `Opacity` item property not being considered legal for clothes
+* Fix the "Parse" button in the fortune wheel customization menu raising if the name is empty
+
 ## v1.8.3
 * Adapt the mobile button tooltip patch to a BC hotfix
 

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.8.3.dev0
+// @version      1.8.4.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.8.3
+// @version      1.8.4
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.8.3",
+    "version": "1.8.4",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     },
     "dependencies": {
         "@types/lodash-es": "^4.17.12",
-        "bc-data": "^115.0.0",
-        "bc-stubs": "^115.0.0",
+        "bc-data": "^116.0.0-Beta.1",
+        "bc-stubs": "^116.0.0-Beta.1",
         "bondage-club-mod-sdk": "^1.2.0",
         "lodash-es": "^4.17.21",
         "typed-scss-modules": "^8.1.1"

--- a/src/common_bc.ts
+++ b/src/common_bc.ts
@@ -244,8 +244,12 @@ export class FWSelectedItemSet extends MBSSelectedObject<FWItemSet> {
     /**
      * Update this instance with settings from the provided item set.
      */
-    writeSettings(): FWItemSet {
-        if (this.name === null || this.itemList === null) {
+    writeSettings(isPreview: boolean = false): FWItemSet {
+        let name = this.name;
+        if (isPreview) {
+            name ??= "preview";
+        }
+        if (name === null || this.itemList === null) {
             throw new Error("Cannot create an ItemSet while \"name\" or \"itemList\" is null");
         }
 
@@ -261,7 +265,7 @@ export class FWSelectedItemSet extends MBSSelectedObject<FWItemSet> {
         }
 
         return new FWItemSet(
-            this.name,
+            name,
             this.itemList,
             this.mbsList,
             this.stripLevel,

--- a/src/fortune_wheel/fortune_wheel_item_set.tsx
+++ b/src/fortune_wheel/fortune_wheel_item_set.tsx
@@ -655,7 +655,7 @@ export class FWItemSetScreen extends MBSObjectScreen<FWItemSet> {
                 return condition(asset);
             }
         });
-        fortuneWheelEquip("MBSPreview", items, this.settings.stripLevel, this.preview, this.settings.writeSettings().activeHooks, null, Player);
+        fortuneWheelEquip("MBSPreview", items, this.settings.stripLevel, this.preview, this.settings.writeSettings(true).activeHooks, null, Player);
         this.#previewUpdate = false;
     }
 

--- a/src/fortune_wheel/item_bundle.ts
+++ b/src/fortune_wheel/item_bundle.ts
@@ -70,14 +70,11 @@ const PROP_MAPPING = <Readonly<PropMappingType>>Object.freeze({
         if (typeof p === "number") {
             return p <= a.MaxOpacity && p >= a.MinOpacity;
         } else if (isArray(p)) {
-            const layers = ItemColorGetColorableLayers({ Asset: a });
             return p.every((opacity, i) => {
-                const layer = layers[i];
-                if (!layer) {
-                    return false;
-                }
+                const layer = a.Layer[i];
                 return (
-                    typeof opacity === "number"
+                    layer != null
+                    && typeof opacity === "number"
                     && opacity <= 1
                     && opacity >= 0
                 );
@@ -134,7 +131,10 @@ function sanitizeProperties(asset: Asset, properties?: ItemProperties): ItemProp
         return {};
     }
 
-    const validPropKeys: Set<keyof ItemProperties> = new Set(["OverridePriority"]);
+    const validPropKeys: Set<keyof ItemProperties> = new Set([
+        "OverridePriority",
+        asset.EditOpacity ? "Opacity" : null,
+    ].filter((i): i is keyof ItemProperties => i != null));
     if (asset.Archetype) {
         const item: Item = { Asset: asset, Property: properties };
         const options = ExtendedItemGatherOptions(item);


### PR DESCRIPTION
Closes https://github.com/bananarama92/MBS/issues/218

* Add support for BC R116Beta1
* Fix the `Opacity` item property not being considered legal for clothes
* Fix the "Parse" button in the fortune wheel customization menu raising if the name is empty