### PR TITLE
REL: Version bump: 1.9.0 > 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MBS Changelog
 
+## v1.9.1
+* Add BC R117Beta1 support
+* Fix an issue wherein the wheel of fortune preview character would fail to render
+
 ## v1.9.0
 * Backport the crafting mass import + export functionality
     - [BondageProjects/Bondage-College#5618](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5618): Add an importer + exporter for entire crafting inventories

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.9.0.dev0
+// @version      1.9.1.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.9.0
+// @version      1.9.1
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     },
     "dependencies": {
         "@types/lodash-es": "^4.17.12",
-        "bc-data": "^116.0.0",
-        "bc-stubs": "^116.0.0",
+        "bc-data": "^117.0.0-Beta.1",
+        "bc-stubs": "^117.0.0-Beta.1",
         "bondage-club-mod-sdk": "^1.2.0",
         "lodash-es": "^4.17.21",
         "typed-scss-modules": "^8.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.9.0",
+    "version": "1.9.1",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/backport-crafting-json.scss
+++ b/src/backport-crafting-json.scss
@@ -63,6 +63,7 @@ dialog::backdrop {
 
 .aside > .description ol {
 	margin-block: unset;
+	padding-left: 1.15em;
 }
 
 fieldset[name="import"] {
@@ -83,6 +84,7 @@ fieldset[name="import"] > legend {
 }
 
 fieldset[name="import"] > input[type="file"] {
+	color: black;
 	grid-area: file;
 	margin-top: var(--half-gap);
 	min-height: calc(1.35em + 6px);

--- a/src/fortune_wheel/fortune_wheel_item_set.scss
+++ b/src/fortune_wheel/fortune_wheel_item_set.scss
@@ -2,7 +2,7 @@
 	--gap: min(2dvh, 1dvw);
 	--height: min(7dvh, 3.5dvw);
 
-	background: var(--mbs-background-color);
+	background: unset;
 	grid-template:
 		"menubar menubar menubar menubar menubar menubar menubar" min(9dvh, 4.5dvw)
 		". . name-input name-input . . ." var(--height)


### PR DESCRIPTION
Closes https://github.com/bananarama92/MBS/issues/224

## v1.9.1
* Add BC R117Beta1 support
* Fix an issue wherein the wheel of fortune preview character would fail to render