### PR TITLE
REL: Version bump: 1.9.2 > 1.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # MBS Changelog
 
+## v1.9.3
+* Add BC R118Beta1 support
+* Backport one BC R118 bug fix:
+    - [BondageProjects/Bondage-College#5674](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5674): Fix `ExtendedItemSetOptionByRecord()` unconditionally failing to handle non-extended items
+
 ## v1.9.2
 * Drop R116 support
 * Fix the cancel button being disabled when creating a new wheel item set

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.9.2.dev0
+// @version      1.9.3.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.9.2
+// @version      1.9.3
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     },
     "dependencies": {
         "@types/lodash-es": "^4.17.12",
-        "bc-data": "^117.0.0",
-        "bc-stubs": "^117.0.0",
+        "bc-data": "^118.0.0-Beta.1",
+        "bc-stubs": "^118.0.0-Beta.1",
         "bondage-club-mod-sdk": "^1.2.0",
         "lodash-es": "^4.17.21",
         "typed-scss-modules": "^8.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.9.2",
+    "version": "1.9.3",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/backport.tsx
+++ b/src/backport.tsx
@@ -19,7 +19,17 @@ export const backportIDs: Set<number> = new Set();
 waitForBC("backport", {
     async afterLoad() {
         switch (GameVersion) {
-            case "R117": {
+            case "R117":
+            case "R118Beta1": {
+                if (MBS_MOD_API.getOriginalHash("ExtendedItemSetOptionByRecord") === "E6FC165D") {
+                    backportIDs.add(5674);
+                    MBS_MOD_API.patchFunction("ExtendedItemSetOptionByRecord", {
+                        "if (item?.Asset?.Archetype == null) return;":
+                            "if (!item) return;",
+                        "const previousOptions = ExtendedItemGatherOptions(item);":
+                            "const previousOptions = item.Asset.Archetype == null ? [] : ExtendedItemGatherOptions(item);",
+                    });
+                }
                 break;
             }
         }

--- a/src/new_items_screen/index.tsx
+++ b/src/new_items_screen/index.tsx
@@ -117,13 +117,13 @@ waitForBC("new_items_screen", {
                     root.querySelector("option[selected]")?.setAttribute("value", "");
                     document.body.append(root);
                 }
-                root.toggleAttribute("data-unload", false);
+                root.toggleAttribute("hidden", false);
             },
             Resize: () => {
                 ElementPositionFix(IDs.root, 36, ...Shop2.Elements.MBS.Coords);
             },
             Unload: () => {
-                document.getElementById(IDs.root)?.toggleAttribute("data-unload", true);
+                document.getElementById(IDs.root)?.toggleAttribute("hidden", true);
             },
             Exit: () => {
                 ElementRemove(IDs.root);

--- a/src/new_items_screen/shop.scss
+++ b/src/new_items_screen/shop.scss
@@ -2,10 +2,6 @@
     display: grid;
     grid-template-rows: 2fr 3fr;
 
-    &[data-unload] {
-        display: none;
-    }
-
     & > span {
         color: white;
         place-self: center center;


### PR DESCRIPTION
Closes https://github.com/bananarama92/MBS/issues/229

* Add BC R118Beta1 support
* Backport one BC R118 bug fix:
    - [BondageProjects/Bondage-College#5674](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/5674): Fix `ExtendedItemSetOptionByRecord()` unconditionally failing to handle non-extended items