### PR TITLE
REL: Version bump: 1.10.2 -> 1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # MBS Changelog
 
+## v1.10.3
+* Move all MBS server crafts to BC starting from the full C R121 (non-beta) release
+    - Starting from the full BC R121 release all "MBS (Account)" crafted items will be moved to base BC, utilizing its increase in crafting slot (from 80 to 200).
+      As a reminder: ensure that enough empty slots remain available for the migration.
+* Increase the max number of local MBS crafting slots from 160 to 600
+* Add support for BC R121Beta1
+* Fix an issue wherein registering MBS wheel of fortune listeners could crash if BC is insufficiently loaded at that point
+* Ensure that the extensions preference subscreen is re-opened via `PreferenceOpenSubscreen()`
+
 ## v1.10.2
 * Vendor the ES module version of Dexie in order to circumvent its version check
     - Prevents Dexie's "Two different versions of Dexie loaded in the same" error from popping up if addons happen to be using mismatched versions

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.10.2.dev0
+// @version      1.10.3.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.10.2
+// @version      1.10.3
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @include      /^https:\/\/(www\.)?bondageprojects\.elementfx\.com\/R\d+\/(BondageClub|\d+)(\/((index|\d+)\.html)?)?$/

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     },
     "dependencies": {
         "@types/lodash-es": "^4.17.12",
-        "bc-data": "^120.0.0",
-        "bc-stubs": "^120.0.0",
+        "bc-data": "^121.0.0-Beta.1",
+        "bc-stubs": "^121.0.0-Beta.1",
         "bondage-club-mod-sdk": "^1.2.0",
         "lodash-es": "^4.17.21",
         "typed-scss-modules": "^8.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.10.2",
+    "version": "1.10.3",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/crafting/dexie.ts
+++ b/src/crafting/dexie.ts
@@ -66,7 +66,7 @@ export function saveCraft(db: Dexie, index: number, craft: null | CraftingItem):
     const table: Table<CraftingDBData, number, CraftingDBData> = db.table("crafting");
     if (craft) {
         logger.debug(`Saving craft ${index + maxBC + maxMBSServer} to indexedDB: ${craft.Name} (${craft.Item})`);
-        return table.put({ id: index, data: craft }, index);
+        return table.put({ id: index, data: craft });
     } else {
         logger.debug(`Deleting craft ${index + maxBC + maxMBSServer} from indexedDB`);
         return table.delete(index);
@@ -87,9 +87,8 @@ export async function saveAllCraft(db: Dexie, crafts: readonly (null | CraftingI
     logger.debug(`Saving all ${putIndices.length} crafts to indexedDB`);
 
     const table: Table<CraftingDBData, number, CraftingDBData> = db.table("crafting");
-    table.bulkPut(craftStrings.filter(i => i != null), putIndices);
     return Promise.all([
-        table.bulkPut(craftStrings.filter(i => i != null), putIndices),
+        table.bulkPut(craftStrings.filter(i => i != null)),
         table.bulkDelete(deleteIndices),
     ]);
 }

--- a/src/crafting/dexie.ts
+++ b/src/crafting/dexie.ts
@@ -19,7 +19,7 @@ export function getSegmentSizes() {
     const version = Version.fromBCVersion(GameVersion);
     const maxBC = GameVersion === "R120" ? 80 : 200;
     const maxMBSServer = (version.major === 120 || (version.major === 121 && version.beta)) ? 80 : 0;
-    const maxMBSLocal = GameVersion === "R120" ? 160 : 600;
+    const maxMBSLocal = 600;
     return { maxBC, maxMBSServer, maxMBSLocal };
 }
 

--- a/src/crafting/dexie.ts
+++ b/src/crafting/dexie.ts
@@ -40,7 +40,7 @@ export function encodeVersion(version: Version): number {
  * @param version
  */
 export function decodeVersion(version: number): Version {
-    const view = new DataView(new ArrayBuffer(8), 0);
+    const view = new DataView(new ArrayBuffer(4), 0);
     view.setUint32(0, version);
     return new Version(view.getUint8(0), view.getUint8(1), view.getUint16(2));
 }

--- a/src/crafting/dexie.ts
+++ b/src/crafting/dexie.ts
@@ -16,8 +16,9 @@ interface CraftingDBData {
 }
 
 export function getSegmentSizes() {
+    const version = Version.fromBCVersion(GameVersion);
     const maxBC = GameVersion === "R120" ? 80 : 200;
-    const maxMBSServer = GameVersion === "R120" ? 80 : 0;
+    const maxMBSServer = (version.major === 120 || (version.major === 121 && version.beta)) ? 80 : 0;
     const maxMBSLocal = GameVersion === "R120" ? 160 : 600;
     return { maxBC, maxMBSServer, maxMBSLocal };
 }

--- a/src/crafting/dexie.ts
+++ b/src/crafting/dexie.ts
@@ -3,6 +3,7 @@ import { Dexie, Table, PromiseExtended } from "../dexie";
 
 import { Version, logger } from "../common";
 
+// TODO: Update once R121 has been released
 export const BC_SLOT_MAX_ORIGINAL = 80;
 export const MBS_SLOT_MAX_SERVER = 160;
 export const MBS_SLOT_MAX_LOCAL = 320;
@@ -12,6 +13,13 @@ const SHORT_CLAMP = 2**16 - 1;
 interface CraftingDBData {
     id: number;
     data: CraftingItem;
+}
+
+export function getSegmentSizes() {
+    const maxBC = GameVersion === "R120" ? 80 : 200;
+    const maxMBSServer = GameVersion === "R120" ? 80 : 0;
+    const maxMBSLocal = GameVersion === "R120" ? 160 : 600;
+    return { maxBC, maxMBSServer, maxMBSLocal };
 }
 
 /**
@@ -53,12 +61,13 @@ export function saveCraft(db: Dexie, index: number, craft: null): PromiseExtende
 export function saveCraft(db: Dexie, index: number, craft: CraftingItem): PromiseExtended<number>;
 export function saveCraft(db: Dexie, index: number, craft: null | CraftingItem): PromiseExtended<void | number>;
 export function saveCraft(db: Dexie, index: number, craft: null | CraftingItem): PromiseExtended<void | number> {
+    const { maxBC, maxMBSServer } = getSegmentSizes();
     const table: Table<CraftingDBData, number, CraftingDBData> = db.table("crafting");
     if (craft) {
-        logger.debug(`Saving craft ${index + MBS_SLOT_MAX_SERVER} to indexedDB: ${craft.Name} (${craft.Item})`);
+        logger.debug(`Saving craft ${index + maxBC + maxMBSServer} to indexedDB: ${craft.Name} (${craft.Item})`);
         return table.put({ id: index, data: craft }, index);
     } else {
-        logger.debug(`Deleting craft ${index + MBS_SLOT_MAX_SERVER} from indexedDB`);
+        logger.debug(`Deleting craft ${index + maxBC + maxMBSServer} from indexedDB`);
         return table.delete(index);
     }
 }
@@ -106,21 +115,23 @@ function craftingValidate(craft: unknown, index: number) {
 }
 
 export async function loadCraft(db: Dexie, index: number): Promise<null | CraftingItem> {
+    const { maxBC, maxMBSServer } = getSegmentSizes();
     const table: Table<CraftingDBData, number, CraftingDBData> = db.table("crafting");
     const craftObj = await table.get(index);
-    const craft = craftingValidate(craftObj?.data, MBS_SLOT_MAX_SERVER + index);
+    const craft = craftingValidate(craftObj?.data, maxBC + maxMBSServer + index);
     if (craft) {
-        logger.debug(`Loading craft ${index + MBS_SLOT_MAX_SERVER} from indexedDB: ${craft.Name} (${craft.Item})`);
+        logger.debug(`Loading craft ${index + maxBC + maxMBSServer} from indexedDB: ${craft.Name} (${craft.Item})`);
     } else {
-        logger.debug(`Loading empty craft ${index + MBS_SLOT_MAX_SERVER} from indexedDB`);
+        logger.debug(`Loading empty craft ${index + maxBC + maxMBSServer} from indexedDB`);
     }
     return craft;
 }
 
 export async function loadAllCraft(db: Dexie): Promise<(null | CraftingItem)[]> {
+    const { maxBC, maxMBSServer, maxMBSLocal } = getSegmentSizes();
     const table: Table<CraftingDBData, number, CraftingDBData> = db.table("crafting");
-    const craftStructs = await table.bulkGet(range(0, MBS_SLOT_MAX_LOCAL - MBS_SLOT_MAX_SERVER));
-    const crafts = craftStructs.map((obj, i) => craftingValidate(obj?.data, MBS_SLOT_MAX_SERVER + i));
+    const craftStructs = await table.bulkGet(range(0, maxMBSLocal));
+    const crafts = craftStructs.map((obj, i) => craftingValidate(obj?.data, maxBC + maxMBSServer + i));
     const nCrafts = crafts.filter(i => i != null).length;
     logger.debug(`Loading all ${nCrafts} crafts from indexedDB`);
     return crafts;

--- a/src/crafting/index.tsx
+++ b/src/crafting/index.tsx
@@ -323,6 +323,32 @@ waitForBC("crafting", {
             loadCraftingCache(Player, Player.MBSSettings.CraftingCache);
         }
 
+        if (version.major === 121 && version.beta) {
+            const nCrafts = Player.Crafting.slice(maxBC, maxBC + maxMBSServer).filter(i => i != null);
+            const psa = <div class="chat-room-changelog" id="mbs-craft-psa-r121">
+                Starting from the full BC R121 release all <code>{nCrafts.length}</code> <q>MBS (Account)</q> crafted items will be moved to base BC, utilizing its increase in crafting slot (from 80 to 200).
+                <br/>
+                As a reminder: ensure that enough empty slots remain available for the migration.
+            </div> as HTMLDivElement;
+            psa.setAttribute("data-sender", Player.MemberNumber.toString());
+            psa.setAttribute("data-time", ChatRoomCurrentTime());
+            psa.classList.add("ChatMessage");
+
+            if (CurrentScreen === "ChatRoom") {
+                ChatRoomAppendChat(psa);
+            } else {
+                let published = false;
+                MBS_MOD_API.hookFunction("ChatRoomCreateElement", 0, (args, next) => {
+                    const ret = next(args);
+                    if (!published) {
+                        published = true;
+                        ChatRoomAppendChat(psa);
+                    }
+                    return ret;
+                });
+            }
+        }
+
         if (CurrentScreen === "Crafting") {
             loadHook();
         }

--- a/src/crafting/index.tsx
+++ b/src/crafting/index.tsx
@@ -261,14 +261,14 @@ waitForBC("crafting", {
 
         const version = Version.fromBCVersion(GameVersion);
         const { maxBC, maxMBSServer, maxMBSLocal } = getSegmentSizes();
-        let db: Dexie;
+        const db: Dexie = openDB(Player.MemberNumber);
+        db.close({ disableAutoOpen: false });
 
         async function loadHook() {
             if (!document.getElementById(IDs.style)) {
                 document.body.append(<style id={IDs.style}>{styles.toString()}</style>);
             }
 
-            db = openDB(Player.MemberNumber);
             padArray(Player.Crafting, maxBC + maxMBSServer + maxMBSLocal, null);
             for (const [i, craft] of (await loadAllCraft(db)).entries()) {
                 Player.Crafting[i + maxBC + maxMBSServer] = craft;
@@ -312,7 +312,7 @@ waitForBC("crafting", {
 
         MBS_MOD_API.hookFunction("CraftingExit", 0, (args, next) => {
             if (CraftingMode === "Slot") {
-                db.close();
+                db.close({ disableAutoOpen: false });
             }
             return next(args);
         });

--- a/src/fortune_wheel/events/register.tsx
+++ b/src/fortune_wheel/events/register.tsx
@@ -248,11 +248,15 @@ export class WheelHookRegister implements _WheelHookRegister {
      * @param options
      * @returns
      */
-    addEventListener<T extends ExtendedWheelEvents.Events.Names>(
+    async addEventListener<T extends ExtendedWheelEvents.Events.Names>(
         hookType: T,
         registrationData: import ("bondage-club-mod-sdk").ModSDKModInfo,
         options: ExtendedWheelEvents.Options<T>,
     ) {
+        if (document.readyState !== "complete") {
+            await new Promise(resolve => document.addEventListener("load", resolve));
+        }
+
         if (this[hookType].some(i => i.registrationData.name === registrationData.name && i.hookName === options.hookName)) {
             throw new Error(`Hook "${registrationData.name}-${hookType}-${options.hookName}" has already been registered`);
         }

--- a/src/lpgl/common.ts
+++ b/src/lpgl/common.ts
@@ -392,11 +392,11 @@ async function contentLoadedListener() {
 export function waitForBC(
     name: BCListenerNames,
     listeners: {
-        /** To be executed after the documents `DOMContentLoaded` event */
+        /** To be executed after the documents `load` event */
         afterLoad?: () => Promise<void>,
         /** To be executed after logging in and running `afterLoad` */
         afterLogin?: () => Promise<void>,
-        /** To be executed after the documents `DOMContentLoaded` event */
+        /** To be executed after logging in and setting up the player's MBS settings */
         afterMBS?: () => Promise<void>,
     },
 ) {
@@ -422,9 +422,10 @@ export function waitForBC(
         return false;
     }
 
-    document.addEventListener("DOMContentLoaded", contentLoadedListener);
     if (document.readyState === "complete") {
         contentLoadedListener();
+    } else {
+        document.addEventListener("load", contentLoadedListener);
     }
     return true;
 }

--- a/src/settings/settings.tsx
+++ b/src/settings/settings.tsx
@@ -20,7 +20,7 @@ import {
     waitForBC,
 } from "../common_bc";
 import { FORTUNE_WHEEL_DEFAULT_BASE } from "../fortune_wheel";
-import { BC_SLOT_MAX_ORIGINAL, deleteDB } from "../crafting";
+import { deleteDB } from "../crafting";
 import { garblingJSON } from "../garbling";
 
 import { showChangelog } from "./changelog";
@@ -318,7 +318,7 @@ export function clearMBSSettings(): void {
 
     WheelFortuneOption = WheelFortuneOption.filter(o => o.Custom !== true);
     WheelFortuneDefault = FORTUNE_WHEEL_DEFAULT_BASE;
-    Player.Crafting = Player.Crafting.slice(0, BC_SLOT_MAX_ORIGINAL);
+    Player.Crafting = Player.Crafting.slice(0, GameVersion === "R120" ? 80 : 200);
     Player.MBSSettings = Object.seal({
         AlternativeGarbling: false,
         CraftingCache: "",

--- a/src/settings/settings_screen.tsx
+++ b/src/settings/settings_screen.tsx
@@ -22,12 +22,7 @@ export class PreferenceScreenProxy extends ScreenProxy {
     constructor() {
         const load = async () => {
             await CommonSetScreen("Character", "Preference");
-            PreferencePageCurrent = 1;
-            const screen = PreferenceSubscreens.find(e => e.name === "Extensions");
-            if (screen) {
-                screen.load?.();
-                PreferenceSubscreen = screen;
-            }
+            PreferenceOpenSubscreen("Extensions");
         };
 
         super(


### PR DESCRIPTION
* Move all MBS server crafts to BC starting from the full C R121 (non-beta) release
    - Starting from the full BC R121 release all "MBS (Account)" crafted items will be moved to base BC, utilizing its increase in crafting slot (from 80 to 200).
      As a reminder: ensure that enough empty slots remain available for the migration.
* Increase the max number of local MBS crafting slots from 160 to 600
* Add support for BC R121Beta1
* Fix an issue wherein registering MBS wheel of fortune listeners could crash if BC is insufficiently loaded at that point
* Ensure that the extensions preference subscreen is re-opened via `PreferenceOpenSubscreen()`