### PR TITLE
REL: Version bump: 1.10.13 -> 1.10.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # MBS Changelog
 
+## v1.10.14
+* Use a patch rather than an override for player character `CanChangeClothesOn` patching
+* (Partially) backport two more R128 bug fixes
+    - [BondageProjects/Bondage-College#6271](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6271): Fix `ServerRoomSearch` same-request check being broken
+    - [BondageProjects/Bondage-College#6273](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6273): Fix Private NPC not being set to the "player in trial" state
+
 ## v1.10.13
 * Drop BC R126 support
 * Minor standardization changes of the MBS screen layouts

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.10.13.dev0
+// @version      1.10.14.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.10.13
+// @version      1.10.14
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @match        https://*.bondageprojects.elementfx.com/R*/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.10.13",
+    "version": "1.10.14",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/backport.tsx
+++ b/src/backport.tsx
@@ -41,15 +41,29 @@ waitForBC("backport", {
     async afterLoad() {
         switch (GameVersion) {
             case "R127": {
-                if (MBS_MOD_API.getOriginalHash("CharacterCreate") === "3E75642F") {
+                if (
+                    MBS_MOD_API.getOriginalHash("CharacterCreate") === "3E75642F"
+                    && MBS_MOD_API.getOriginalHash("Player.CanChangeClothesOn") === "978C7F10"
+                ) {
                     backportIDs.add(6258);
                     MBS_MOD_API.hookFunction("CharacterCreate", 0, (args, next) => {
                         const ret = next(args);
                         ret.CanChangeClothesOn = canChangeClothesOn;
                         return ret;
                     });
-                    Character.forEach(C => C.CanChangeClothesOn = canChangeClothesOn);
+                    MBS_MOD_API.patchFunction("Player.CanChangeClothesOn", {
+                        ["InventoryGet(CurrentCharacter, \"ItemNeck\") !== null"]:
+                            "InventoryGet(C, \"ItemNeck\") !== null",
+                        ["InventoryGet(CurrentCharacter, \"ItemNeck\").Asset.Name"]:
+                            "InventoryGet(C, \"ItemNeck\").Asset.Name",
+                    });
+                    for (const char of Character) {
+                        if (!char.IsPlayer()) {
+                            char.CanChangeClothesOn = canChangeClothesOn;
+                        }
+                    }
                 }
+
                 if (MBS_MOD_API.getOriginalHash("InventoryRemove") === "1D6A6339") {
                     backportIDs.add(6267);
                     MBS_MOD_API.patchFunction("InventoryRemove", {

--- a/src/backport.tsx
+++ b/src/backport.tsx
@@ -37,6 +37,10 @@ function canChangeClothesOn(this: Character, C: Character): boolean {
     }
 }
 
+function isOwner(this: Character): boolean {
+    return Player.IsOwnedByCharacter(this);
+}
+
 waitForBC("backport", {
     async afterLoad() {
         switch (GameVersion) {
@@ -71,6 +75,43 @@ waitForBC("backport", {
                             "if (C.IsPlayer()) { BlindFlashQueue = true; }",
                     });
                 }
+
+                if (
+                    MBS_MOD_API.getOriginalHash("CharacterCreate") === "3E75642F"
+                    && MBS_MOD_API.getOriginalHash("Player.IsOwner") === "A57439A6"
+                ) {
+                    backportIDs.add(6273);
+                    MBS_MOD_API.hookFunction("CharacterCreate", 0, (args, next) => {
+                        const ret = next(args);
+                        ret.IsOwner = isOwner;
+                        return ret;
+                    });
+                    MBS_MOD_API.patchFunction("Player.IsOwner", {
+                        ["if (this.IsNpc() && !NPCEventGet(this, \"PlayerCollaring\")) return false;"]:
+                            ";",
+                    });
+                    for (const char of Character) {
+                        if (!char.IsPlayer()) {
+                            char.IsOwner = isOwner;
+                        }
+                    }
+                }
+
+                if (
+                    MBS_MOD_API.getOriginalHash("ServerRoomSearch") === "A765CB69"
+                    && MBS_MOD_API.getOriginalHash("ChatRoomSetLastChatRoom") === "1417FC0B"
+                ) {
+                    backportIDs.add(6271);
+                    MBS_MOD_API.patchFunction("ServerRoomSearch", {
+                        "CommonObjectEqual(ServerRoomSearchLastQuery, request)":
+                            "CommonDeepEqual(ServerRoomSearchLastQuery, request)",
+                    });
+                    MBS_MOD_API.patchFunction("ChatRoomSetLastChatRoom", {
+                        "} else {":
+                            "} else if (Player.LastChatRoom !== null || Player.LastMapData !== null) {",
+                    });
+                }
+
                 if (!document.getElementById("mbs-backport-style")) {
                     document.body.append(<style id="mbs-backport-style">{styles.toString()}</style>);
                 }


### PR DESCRIPTION
* Use a patch rather than an override for player character `CanChangeClothesOn` patching
* (Partially) backport two more R128 bug fixes
    - [BondageProjects/Bondage-College#6271](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6271): Fix `ServerRoomSearch` same-request check being broken
    - [BondageProjects/Bondage-College#6273](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6273): Fix Private NPC not being set to the "player in trial" state