### PR TITLE
REL: Version bump: 1.10.15 -> 1.10.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # MBS Changelog
 
+## v1.10.16
+* Fix an issue wherein two backports would register too early, rendering them non-functional (xref [BondageProjects/Bondage-College#6273](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6273) and [BondageProjects/Bondage-College#6258](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6258))
+
 ## v1.10.15
 * Fix the `CharacterCreate` hook triggering "Unknown mod not using ModSDK" warnings
 

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.10.15.dev0
+// @version      1.10.16.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.10.15
+// @version      1.10.16
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @match        https://*.bondageprojects.elementfx.com/R*/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.10.15",
+    "version": "1.10.16",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/backport.tsx
+++ b/src/backport.tsx
@@ -42,7 +42,8 @@ function isOwner(this: Character): boolean {
 }
 
 waitForBC("backport", {
-    async afterLoad() {
+    // TODO: Change back to `afterLoad` once R128 is live
+    async afterLogin() {
         switch (GameVersion) {
             case "R127": {
                 if (


### PR DESCRIPTION
* Fix an issue wherein two backports would register too early, rendering them non-functional (xref [BondageProjects/Bondage-College#6273](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6273) and [BondageProjects/Bondage-College#6258](https://gitgud.io/BondageProjects/Bondage-College/-/merge_requests/6258))