### PR TITLE
REL: Version bump: 1.10.18 -> 1.10.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MBS Changelog
 
+## v1.10.19
+* Drop BC R128 support
+* Add BC R130Beta1 support
+
 ## v1.10.18
 * Add BC R129Beta1 support
 * Drop BC R127 support

--- a/dev_loader.user.js
+++ b/dev_loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS_dev - Maid's Bondage Scripts Development Version
 // @namespace    MBS_dev
-// @version      1.10.18.dev0
+// @version      1.10.19.dev0
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod (dev version)
 // @author       Bananarama92
 // @match        http://localhost:*/*

--- a/loader.user.js
+++ b/loader.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         MBS - Maid's Bondage Scripts
 // @namespace    MBS
-// @version      1.10.18
+// @version      1.10.19
 // @description  Loader of Bananarama92's "Maid's Bondage Scripts" mod
 // @author       Bananarama92
 // @match        https://*.bondageprojects.elementfx.com/R*/*

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     },
     "dependencies": {
         "@types/lodash-es": "^4.17.12",
-        "bc-data": "^129.0.0-Beta.1",
-        "bc-stubs": "^129.0.0-Beta.1",
+        "bc-data": "^130.0.0-Beta.1",
+        "bc-stubs": "^130.0.0-Beta.1",
         "bondage-club-mod-sdk": "^1.2.0",
         "lodash-es": "^4.18.1",
         "typed-scss-modules": "^8.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "maids-bondage-scripts",
-    "version": "1.10.18",
+    "version": "1.10.19",
     "private": true,
     "description": "Various additions and utility scripts for BC",
     "homepage": "https://github.com/bananarama92/MBS#readme",

--- a/src/backport.tsx
+++ b/src/backport.tsx
@@ -19,7 +19,7 @@ export const backportIDs: Set<number> = new Set();
 waitForBC("backport", {
     async afterLoad() {
         switch (GameVersion) {
-            case "R128": {
+            case "R129": {
                 break;
             }
         }

--- a/src/lpgl/common.ts
+++ b/src/lpgl/common.ts
@@ -269,7 +269,7 @@ export class Version {
 }
 
 /** The minimum supported BC version. */
-export const BC_MIN_VERSION = 128 satisfies number;
+export const BC_MIN_VERSION = 129 satisfies number;
 
 const bcListenerNames = [
     "api",


### PR DESCRIPTION
* Drop BC R128 support
* Add BC R130Beta1 support